### PR TITLE
fix: keep filters when reviewing a proposal

### DIFF
--- a/app/routes/team+/$team.$event+/reviews+/__components/proposal-page/review-sidebar-sections/review-form.tsx
+++ b/app/routes/team+/$team.$event+/reviews+/__components/proposal-page/review-sidebar-sections/review-form.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSubmit } from '@remix-run/react';
+import { useParams, useSearchParams, useSubmit } from '@remix-run/react';
 
 import { H2 } from '~/design-system/typography.tsx';
 import type { ReviewFeeling, UserReview } from '~/types/proposals.types.ts';
@@ -8,13 +8,17 @@ import { ReviewSelector } from './review-selector.tsx';
 type Props = { initialValues: UserReview };
 
 export function ReviewForm({ initialValues }: Props) {
-  const params = useParams();
-  const submit = useSubmit();
+  const [searchParams] = useSearchParams();
+  const filters = searchParams.toString();
 
+  const params = useParams();
+  const actionUrl = `/team/${params.team}/${params.event}/reviews/${params.proposal}`;
+
+  const submit = useSubmit();
   const handleSubmit = (feeling: ReviewFeeling, note: number | null) => {
     submit(
       { intent: 'add-review', feeling, note: note === null ? '' : note },
-      { method: 'POST', action: `/team/${params.team}/${params.event}/reviews/${params.proposal}` },
+      { method: 'POST', action: filters ? `${actionUrl}?${filters}` : actionUrl },
     );
   };
 


### PR DESCRIPTION
Fix #286 