### PR TITLE
feat: add comments count on proposals list

### DIFF
--- a/app/.server/reviews/cfp-reviews-search.test.ts
+++ b/app/.server/reviews/cfp-reviews-search.test.ts
@@ -8,6 +8,7 @@ import { userFactory } from 'tests/factories/users.ts';
 
 import { ForbiddenOperationError } from '~/libs/errors.server.ts';
 
+import { commentFactory } from 'tests/factories/comments.ts';
 import { eventProposalTagFactory } from 'tests/factories/proposal-tags.ts';
 import { CfpReviewsSearch } from './cfp-reviews-search.ts';
 
@@ -30,6 +31,7 @@ describe('CfpReviewsSearch', () => {
     it('returns event proposals info', async () => {
       const tag = await eventProposalTagFactory({ event });
       const proposal = await proposalFactory({ event, talk: await talkFactory({ speakers: [speaker] }), tags: [tag] });
+      await commentFactory({ proposal: proposal, user: owner });
       const proposals = await CfpReviewsSearch.for(owner.id, team.slug, event.slug).search({ status: 'pending' });
 
       expect(proposals.results).toEqual([
@@ -45,6 +47,7 @@ describe('CfpReviewsSearch', () => {
             summary: { negatives: 0, positives: 0, average: null },
             you: { note: null, feeling: null },
           },
+          comments: { count: 1 },
         },
       ]);
 

--- a/app/.server/reviews/cfp-reviews-search.ts
+++ b/app/.server/reviews/cfp-reviews-search.ts
@@ -51,6 +51,9 @@ export class CfpReviewsSearch {
             summary: event.displayProposalsReviews ? reviews.summary() : undefined,
             you: reviews.ofUser(this.userId),
           },
+          comments: {
+            count: proposal._count.comments,
+          },
         };
       }),
     };

--- a/app/.server/shared/proposal-search-builder.ts
+++ b/app/.server/shared/proposal-search-builder.ts
@@ -31,6 +31,9 @@ export class ProposalSearchBuilder {
       include: {
         speakers: this.options.withSpeakers,
         reviews: this.options.withReviews,
+        _count: {
+          select: { comments: true },
+        },
         tags: true,
       },
       where: this.whereClause(),

--- a/app/routes/__components/reviews/review-comments.tsx
+++ b/app/routes/__components/reviews/review-comments.tsx
@@ -1,0 +1,17 @@
+import { ChatBubbleBottomCenterTextIcon } from '@heroicons/react/24/outline';
+import { Text } from '~/design-system/typography.tsx';
+
+type Props = { count: number };
+
+export function ReviewComments({ count }: Props) {
+  if (count === 0) return null;
+
+  return (
+    <div className="flex items-center flex-row-reverse justify-end gap-1">
+      <ChatBubbleBottomCenterTextIcon className="h-5 w-5 shrink-0" aria-label="Number of comments" />
+      <Text weight="semibold" variant="secondary">
+        {count}
+      </Text>
+    </div>
+  );
+}

--- a/app/routes/__components/reviews/review-comments.tsx
+++ b/app/routes/__components/reviews/review-comments.tsx
@@ -7,11 +7,11 @@ export function ReviewComments({ count }: Props) {
   if (count === 0) return null;
 
   return (
-    <div className="flex items-center flex-row-reverse justify-end gap-1">
-      <ChatBubbleBottomCenterTextIcon className="h-5 w-5 shrink-0" aria-label="Number of comments" />
+    <div className="flex items-center justify-end gap-1">
       <Text weight="semibold" variant="secondary">
         {count}
       </Text>
+      <ChatBubbleBottomCenterTextIcon className="size-5 shrink-0 text-gray-600" aria-label={`${count} comment(s)`} />
     </div>
   );
 }

--- a/app/routes/__components/reviews/review-note.tsx
+++ b/app/routes/__components/reviews/review-note.tsx
@@ -19,15 +19,17 @@ export function GlobalReviewNote({ feeling, note, hideEmpty }: Props) {
   const { icon: Icon, color, stroke, label } = REVIEWS[feeling || 'NEUTRAL'];
   const formattedNote = formatReviewNote(note);
 
+  if (note === null && feeling !== 'NO_OPINION') return <div />;
+
   return (
-    <div className={cx('flex items-center justify-end gap-1 w-14', { invisible: note === null && hideEmpty })}>
+    <div className={cx('flex items-center justify-end gap-1', { invisible: note === null && hideEmpty })}>
       <ClientOnly>
         {() => (
           <>
             <Text weight="semibold" variant="secondary">
               {formattedNote}
             </Text>
-            <Icon className={cx('h-5 w-5 shrink-0', color, stroke)} aria-label={`${label}: ${formattedNote}`} />
+            <Icon className={cx('size-5 shrink-0', color, stroke)} aria-label={`${label}: ${formattedNote}`} />
           </>
         )}
       </ClientOnly>
@@ -36,10 +38,10 @@ export function GlobalReviewNote({ feeling, note, hideEmpty }: Props) {
 }
 
 export function UserReviewNote({ feeling, note }: Props) {
-  if (!feeling) return null;
-
-  const { icon: Icon, color, stroke, label } = REVIEWS[feeling];
+  const { icon: Icon, color, stroke, label } = REVIEWS[feeling || 'NEUTRAL'];
   const formattedNote = formatReviewNote(note);
+
+  if (note === null && feeling !== 'NO_OPINION') return <div />;
 
   return (
     <div className="flex items-center justify-end gap-1">
@@ -50,9 +52,9 @@ export function UserReviewNote({ feeling, note }: Props) {
               {formattedNote}
             </Text>
             {feeling === 'NEUTRAL' ? (
-              <UserCircleIcon className="h-5 w-5 text-gray-700 shrink-0" aria-label={`Your review: ${formattedNote}`} />
+              <UserCircleIcon className="size-5 text-gray-700 shrink-0" aria-label={`Your review: ${formattedNote}`} />
             ) : (
-              <Icon className={cx('h-5 w-5 shrink-0', color, stroke)} aria-label={`Your review: ${label}`} />
+              <Icon className={cx('size-5 shrink-0', color, stroke)} aria-label={`Your review: ${label}`} />
             )}
           </>
         )}

--- a/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/proposal-item.tsx
+++ b/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/proposal-item.tsx
@@ -68,10 +68,10 @@ export function ProposalItem({ proposal, isSelected, isAllPagesSelected, toggle 
           </Text>
         </div>
 
-        <div className="hidden sm:flex sm:items-center sm:gap-6">
+        <div className="hidden sm:flex sm:items-center sm:gap-2 sm:[&>*]:w-14">
+          <ReviewComments count={proposal.comments.count} />
           <UserReviewNote feeling={you.feeling} note={you.note} />
           {summary && <GlobalReviewNote feeling="NEUTRAL" note={summary.average} hideEmpty />}
-          <ReviewComments count={proposal.comments.count} />
         </div>
       </div>
     </>

--- a/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/proposal-item.tsx
+++ b/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/proposal-item.tsx
@@ -7,6 +7,7 @@ import { Text } from '~/design-system/typography.tsx';
 import { GlobalReviewNote, UserReviewNote } from '~/routes/__components/reviews/review-note.tsx';
 
 import { useCurrentTeam } from '~/routes/__components/contexts/team-context.tsx';
+import { ReviewComments } from '~/routes/__components/reviews/review-comments';
 import { Tag } from '~/routes/__components/tags/tag.tsx';
 import type { ProposalData } from './types';
 
@@ -70,6 +71,7 @@ export function ProposalItem({ proposal, isSelected, isAllPagesSelected, toggle 
         <div className="hidden sm:flex sm:items-center sm:gap-6">
           <UserReviewNote feeling={you.feeling} note={you.note} />
           {summary && <GlobalReviewNote feeling="NEUTRAL" note={summary.average} hideEmpty />}
+          <ReviewComments count={proposal.comments.count} />
         </div>
       </div>
     </>

--- a/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/types.ts
+++ b/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/types.ts
@@ -15,5 +15,6 @@ export type ProposalData = {
   confirmationStatus: ConfirmationStatus | null;
   speakers: Array<{ name: string | null; picture: string | null }>;
   reviews: { summary?: GlobalReview; you: UserReview };
+  comments: { count: number };
   tags: Array<Tag>;
 };


### PR DESCRIPTION
Hello,

I've had troubles following on discussions on proposals, so I propose this first PR to display the number of comments on the proposals list. Another PR I have in mind is being able to sort the list by comments count, I'll probably send one soon if you also think it's a good idea :)