### PR TITLE
feat(ux): enlarge proposal item link

### DIFF
--- a/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/proposal-item.tsx
+++ b/app/routes/team+/$team.$event+/reviews+/__components/proposals-list-page/list/proposal-item.tsx
@@ -40,16 +40,14 @@ export function ProposalItem({ proposal, isSelected, isAllPagesSelected, toggle 
         />
       ) : undefined}
 
-      <div className="flex items-center justify-between gap-4 py-3 grow min-w-0">
+      <Link
+        to={{ pathname: id, search: params.toString() }}
+        aria-label={`Open proposal "${title}"`}
+        className="flex items-center justify-between gap-4 py-3 grow min-w-0 hover:text-indigo-700"
+      >
         <div className="space-y-2 md:space-y-1 min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <Link
-              to={{ pathname: id, search: params.toString() }}
-              aria-label={`Open proposal "${title}"`}
-              className="font-semibold hover:text-indigo-700"
-            >
-              {title}
-            </Link>
+            <span className="font-semibold">{title}</span>
 
             {canDeliberateEventProposals && proposal.deliberationStatus !== 'PENDING' ? (
               <>
@@ -73,7 +71,7 @@ export function ProposalItem({ proposal, isSelected, isAllPagesSelected, toggle 
           <UserReviewNote feeling={you.feeling} note={you.note} />
           {summary && <GlobalReviewNote feeling="NEUTRAL" note={summary.average} hideEmpty />}
         </div>
-      </div>
+      </Link>
     </>
   );
 }


### PR DESCRIPTION
Hello 👋 I was reviewing next's Zenika Nantes internal conference, the experience was great overall!

A small thing bugged me on mobile about the proposal selection links which I find too small.

The proposal here is to enlarge the proposal item selection link to the whole line: 

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/a1cee2f2-3d37-495c-8f99-c841ec7d2ea4">

I greyed out the new link size to make it clearer. The checkbox looks safe IMO.

Didn't find a conflict with another link in proposal item component so here is this small PR :) 

Btw the project was super easy to setup locally, I was scared about authentication but what you did there is perfect (never saw the Google profile selection before!) so congrats on that!