### PR TITLE
fix: tracks validation on talk submission

### DIFF
--- a/app/.server/cfp-submission-funnel/talk-submission.types.ts
+++ b/app/.server/cfp-submission-funnel/talk-submission.types.ts
@@ -10,9 +10,9 @@ export const DraftSaveSchema = z.object({
 
 export const TracksMandatorySchema = z.array(z.string()).nonempty();
 
-export const TracksSchema = z.array(z.string()).optional();
+export const TracksOptionalSchema = z.array(z.string()).optional();
 
-const TracksUpdateSchema = z.object({ formats: TracksSchema, categories: TracksSchema });
+const TracksUpdateSchema = z.object({ formats: TracksOptionalSchema, categories: TracksOptionalSchema });
 
 export type DraftSaveData = z.infer<typeof DraftSaveSchema>;
 export type TrackUpdateData = z.infer<typeof TracksUpdateSchema>;

--- a/app/.server/event-page/event-page.test.ts
+++ b/app/.server/event-page/event-page.test.ts
@@ -61,7 +61,7 @@ describe('EventPage', () => {
   });
 
   describe('#buildTracksSchema', () => {
-    it('validates tracks form inputs', async () => {
+    it('validates given tracks', async () => {
       const event = await eventFactory();
       const format = await eventFormatFactory({ event });
       const category = await eventCategoryFactory({ event });
@@ -72,7 +72,7 @@ describe('EventPage', () => {
       expect(result.success && result.data).toEqual({ formats: [format.name], categories: [category.name] });
     });
 
-    it('validates tracks when no tracks', async () => {
+    it('validates no tracks given', async () => {
       const event = await eventFactory();
       await eventFormatFactory({ event });
       await eventCategoryFactory({ event });
@@ -83,7 +83,27 @@ describe('EventPage', () => {
       expect(result.success && result.data).toEqual({ formats: [], categories: [] });
     });
 
-    it('returns errors when no tracks and tracks are mandatory', async () => {
+    it('validates given tracks when tracks are mandatory', async () => {
+      const event = await eventFactory({ attributes: { formatsRequired: true, categoriesRequired: true } });
+      const format = await eventFormatFactory({ event });
+      const category = await eventCategoryFactory({ event });
+
+      const schema = await EventPage.of(event.slug).buildTracksSchema();
+      const result = schema.safeParse({ formats: [format.name], categories: [category.name] });
+
+      expect(result.success && result.data).toEqual({ formats: [format.name], categories: [category.name] });
+    });
+
+    it('validates no tracks given when tracks are mandatory but no track created for the event', async () => {
+      const event = await eventFactory({ attributes: { formatsRequired: true, categoriesRequired: true } });
+
+      const schema = await EventPage.of(event.slug).buildTracksSchema();
+      const result = schema.safeParse({ formats: [], categories: [] });
+
+      expect(result.success && result.data).toEqual({ formats: [], categories: [] });
+    });
+
+    it('returns errors when no tracks given but tracks are mandatory', async () => {
       const event = await eventFactory({ attributes: { formatsRequired: true, categoriesRequired: true } });
       await eventFormatFactory({ event });
       await eventCategoryFactory({ event });

--- a/app/.server/event-page/event-page.ts
+++ b/app/.server/event-page/event-page.ts
@@ -2,7 +2,7 @@ import { db } from 'prisma/db.server.ts';
 
 import { z } from 'zod';
 import { EventNotFoundError } from '~/libs/errors.server.ts';
-import { TracksMandatorySchema, TracksSchema } from '../cfp-submission-funnel/talk-submission.types.ts';
+import { TracksMandatorySchema, TracksOptionalSchema } from '../cfp-submission-funnel/talk-submission.types.ts';
 import { SurveyConfig } from '../event-survey/survey-config.ts';
 
 export class EventPage {
@@ -63,10 +63,10 @@ export class EventPage {
   }
 
   async buildTracksSchema() {
-    const { formatsRequired, categoriesRequired } = await this.get();
+    const { formatsRequired, categoriesRequired, formats, categories } = await this.get();
     return z.object({
-      formats: formatsRequired ? TracksMandatorySchema : TracksSchema,
-      categories: categoriesRequired ? TracksMandatorySchema : TracksSchema,
+      formats: formatsRequired && formats.length > 0 ? TracksMandatorySchema : TracksOptionalSchema,
+      categories: categoriesRequired && categories.length > 0 ? TracksMandatorySchema : TracksOptionalSchema,
     });
   }
 


### PR DESCRIPTION
When a track is marks as required, but no track names are defined, it blocks the talk submission.