### PR TITLE
Feat: OpenPlanner export always show sessions in feedbacks

### DIFF
--- a/app/.server/reviews/jobs/export-to-open-planner.job.test.ts
+++ b/app/.server/reviews/jobs/export-to-open-planner.job.test.ts
@@ -66,6 +66,7 @@ describe('Job: exportToOpenPlanner', () => {
           speakerIds: proposal2.speakers.map((s) => s.id),
           categoryId: category.id,
           categoryName: category.name,
+          showInFeedback: true,
         },
         {
           id: proposal1.id,
@@ -76,6 +77,7 @@ describe('Job: exportToOpenPlanner', () => {
           speakerIds: proposal1.speakers.map((s) => s.id),
           formatId: format.id,
           formatName: format.name,
+          showInFeedback: true,
         },
       ],
       speakers: [

--- a/app/.server/reviews/jobs/export-to-open-planner.job.ts
+++ b/app/.server/reviews/jobs/export-to-open-planner.job.ts
@@ -50,6 +50,7 @@ export const exportToOpenPlanner = job<ExportToOpenPlannerPayload>({
             formatName: format?.name,
             categoryId: category?.id,
             categoryName: category?.name,
+            showInFeedback: true,
           }),
         );
 

--- a/app/libs/integrations/open-planner.ts
+++ b/app/libs/integrations/open-planner.ts
@@ -15,6 +15,7 @@ const OpenPlannerSessionsPayloadSchema = z.object({
       formatName: z.string().nullish(),
       categoryId: z.string().nullish(),
       categoryName: z.string().nullish(),
+      showInFeedback: z.boolean().nullish(),
     }),
   ),
   speakers: z.array(


### PR DESCRIPTION
ConferenceHall events are real talks/sessions, so it makes sense for them to always be shown on feedback.