### PR TITLE
fix(teams): don't escape team names

### DIFF
--- a/app/routes/$event/_layout.tsx
+++ b/app/routes/$event/_layout.tsx
@@ -62,7 +62,7 @@ export default function EventRoute({ loaderData: event }: Route.ComponentProps) 
               {event.name}
             </H1>
             <Text variant="secondary-light" weight="medium">
-              {t('common.by', { names: [event.teamName] })}
+              {t('common.by', { names: [event.teamName], interpolation: { escapeValue: false } })}
             </Text>
           </div>
         </Container>

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -67,9 +67,16 @@ async function seed() {
     team: team2,
   });
 
+  const bdx_io_team = await teamFactory({
+    owners: [user],
+    members: [user2],
+    attributes: { name: 'BDX I/O', slug: 'bdx-io' },
+  });
+
   await eventFactory({
     traits: ['conference-cfp-future'],
-    attributes: { name: 'BDX.io', slug: 'bdx-io' },
+    attributes: { name: 'BDX I/O', slug: 'bdx-io' },
+    team: bdx_io_team,
   });
 
   await eventFactory({


### PR DESCRIPTION
Fixes #477

## Overview 

- Remove the auto-escape on the team's names 
- Add BDX I/O as the Team responsible for the event with the same name, in order to better reproduce the bug 

## Screenshots 

Before | After 
-- | -- 
![image](https://github.com/user-attachments/assets/83b085ea-194a-4820-8b52-73d0433e8d74) | ![image](https://github.com/user-attachments/assets/43dfbf79-d873-4072-b0b7-f5c29cb7b558)


PS: Great job on re-working the platform, both the UX and DevX are WAY better now, makes it a joy to use! ✨ 