### PR TITLE
docs: improve and expand technical documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,8 +21,10 @@ Ideally you should talk about it on [Discussions](https://github.com/conference-
 ## Development
 
 - [Getting started](../README.md#development)
+- [Emails](./emails.md)
 - [Feature flags](./feature-flags.md)
 - [I18N](./i18n.md)
+- [Jobs](./jobs.md)
 - [Timezones](./timezones.md)
 
 ## Legals

--- a/docs/emails.md
+++ b/docs/emails.md
@@ -1,0 +1,116 @@
+# Email System
+
+Conference Hall uses a job-based email system to handle transactional emails, supporting multiple providers and internationalization.
+
+## Email Features
+
+- **Transactional emails** for authentication and proposal workflows
+- **Multi-provider support** (Mailgun for production, Mailpit for development)
+- **Job queue processing** using BullMQ for reliable delivery
+- **React-based templates** with Tailwind CSS styling
+- **Internationalization** support for multiple locales
+
+## Architecture
+
+### Core Components
+
+- **Job System**: `app/emails/send-email.job.ts` - Background job processor
+- **Renderer**: `app/emails/email.renderer.tsx` - Template compilation
+- **Providers**: `app/emails/providers/` - Email delivery services
+- **Templates**: `app/emails/templates/` - React email components
+- **Utilities**: `app/emails/utils/` - Helper functions
+
+### Email Providers
+
+The system supports two email providers (Provider selection is environment-based):
+
+1. **MailgunProvider** - Production email delivery via Mailgun API
+2. **MailpitProvider** - Development email testing via SMTP
+
+
+## React Email Integration
+
+Conference Hall uses [React Email](https://react.email/) to build and render email templates with React components.
+The email renderer compiles React components to HTML and plain text.
+
+### React Email Components
+
+Templates use React Email's semantic components:
+
+```typescript
+import { Button, Heading, Section, Text, Img } from '@react-email/components';
+
+export default function ExampleEmail({ locale, ...props }: EmailProps) {
+  return (
+    <BaseEmail locale={locale}>
+      <Heading className={styles.h1}>Title</Heading>
+      <Text>Content paragraph</Text>
+      <Section className={styles.card}>
+        <Text><strong>Highlighted content</strong></Text>
+      </Section>
+      <Section className="text-center my-[32px]">
+        <Button href={actionUrl} className={styles.button}>
+          Action Button
+        </Button>
+      </Section>
+    </BaseEmail>
+  );
+}
+```
+
+### Styling System
+
+Predefined styles from `base-email.tsx`:
+```typescript
+export const styles = {
+  h1: 'text-xl',
+  logo: 'mx-auto mt-[20px] mb-[32px] rounded-lg',
+  card: 'bg-slate-50 border border-solid border-slate-200 rounded-[8px] px-[20px] my-[20px]',
+  button: 'box-border rounded-[8px] bg-slate-800 px-[24px] py-[12px] w-full text-center font-semibold text-sm text-white',
+};
+```
+
+### Template Development
+
+**Preview Props** - Each template includes preview data for development:
+```typescript
+ExampleEmail.PreviewProps = {
+  locale: 'en',
+  actionUrl: 'https://example.com',
+  // ... other props
+} as EmailProps;
+```
+
+## Sending Emails
+
+### Using Template Functions
+
+Each template exports a convenience function for sending:
+
+```typescript
+// app/emails/templates/auth/email-verification.tsx
+export function sendVerificationEmail(email: string, locale: string, data: TemplateData) {
+  return sendEmail.trigger({
+    template: 'auth/email-verification',
+    subject: 'Verify your email address for Conference Hall',
+    from: 'Conference Hall <no-reply@mg.conference-hall.io>',
+    to: [email],
+    data,
+    locale,
+  });
+}
+```
+
+## Environment Configuration
+
+### Development (Mailpit)
+```env
+MAILPIT_HOST=localhost
+MAILPIT_SMTP_PORT=1025
+```
+
+### Production (Mailgun)
+```env
+MAILGUN_API_KEY=your_mailgun_api_key
+MAILGUN_DOMAIN=your_mailgun_domain
+```

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -31,7 +31,7 @@ const myFlag = await flags.get('my-flag-name');
 To use a flag in the frontend, use the hook `useFlag`, only flags defined with `frontend` tag are available:
 
 ```js
-import { useFlag } from './routes/components/flags-context.tsx';
+import { useFlag } from '~/routes/components/contexts/flags-context.tsx';
 
 const myFlag = useFlag('my-flag-name');
 ```
@@ -57,11 +57,3 @@ test('my test when flags is off', async () => {
 });
 ```
 
-**To change a flag in e2e tests:**
-
-```js
-it('my test when flags is off', async () => {
-  cy.task('setFlag', { key: 'my-flag-name', value: false });
-  // my test...
-});
-```

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -15,7 +15,7 @@
 
 ## Translation files
 
-- JSON translation files are located in `public/locales`.
+- JSON translation files are located in `app/locales`.
 - Keys follow a flat structure.
 - Keys must be sorted alphabetically.
 - Translation files are cached by the web server and versioned using the deployed Git commit SHA.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,120 @@
+# Jobs
+
+Conference Hall uses **BullMQ** with Redis for background job processing. The system provides a custom abstraction layer for type-safe job creation and management.
+
+## Architecture
+
+- **Queue System**: BullMQ with Redis backend
+- **Worker Process**: Separate process (`servers/jobs.ts`) handling job execution
+- **Job Definition**: Custom `job()` function with TypeScript generics
+- **Error Handling**: Automatic retries with exponential backoff
+- **Logging**: Structured logging with job lifecycle events
+
+## Creating Jobs
+
+### Job Configuration Options
+
+```ts
+import { job } from '~/libs/jobs/job.ts';
+
+interface MyJobPayload {
+  userId: string;
+}
+
+export const myJob = job<MyJobPayload>({
+  name: 'unique-job-name',      // Required: Job identifier
+  queue: 'default',             // Optional: Queue name
+  run: async (payload) => {     // Required: Job execution function
+    // Implementation
+    console.log('Processing job for user:', payload.userId);
+  },
+});
+```
+
+**Default Settings:**
+- **Retry attempts**: 5
+- **Backoff strategy**: Exponential with 3000ms delay
+- **Concurrency**: 1 per worker
+- **Job retention**: 1000 completed and failed jobs
+
+## Triggering Jobs
+
+### Basic Usage
+
+```ts
+// Trigger job execution
+await myJob.trigger({
+  userId: 'user-123',
+});
+```
+
+## Testing Jobs
+
+### Unit Testing
+
+Test job logic directly by calling the `run` function:
+
+```ts
+import { myJob } from './my-job.ts';
+
+test('processes job successfully', async () => {
+  const payload = { userId: 'user-123', data: {} };
+  
+  // Call job logic directly
+  await myJob.config.run(payload);
+  
+  // Assert expected behavior
+  expect(/* your assertions */);
+});
+```
+
+### Integration Testing
+
+Jobs are automatically mocked in the test environment.
+
+```ts
+import { sendEmail } from '~/emails/send-email.job.ts';
+
+test('sends email job', async () => {
+  await sendEmail.trigger({
+    template: 'test-template',
+    to: ['test@example.com'],
+    // ... other properties
+  });
+  
+  // Verify job was triggered
+  expect(sendEmail.trigger).toHaveBeenCalledWith({
+    template: 'test-template',
+    to: ['test@example.com'],
+    // ... expected payload
+  });
+});
+```
+
+## Best Practices
+
+1. **Type Safety**: Always define payload interfaces for jobs
+2. **Error Handling**: Let jobs throw errors for automatic retries
+3. **Idempotency**: Design jobs to be safely retryable
+4. **Logging**: Use structured logging for job events
+5. **Testing**: Test job logic separately from queue mechanics
+6. **Payload Size**: Keep job payloads small; store large data in database
+
+## Environment Configuration
+
+Required environment variables:
+- `REDIS_URL` - Redis connection string
+- `DATABASE_URL` - PostgreSQL connection
+
+## Monitoring
+
+Jobs are logged with structured data including:
+- Job name and queue
+- Execution time
+- Success/failure status
+- Error details for failed jobs
+
+Worker events are logged:
+- `ready` - Worker started with available jobs
+- `completed` - Job finished successfully
+- `failed` - Job failed with error details


### PR DESCRIPTION
## Summary
- Fix outdated paths and examples in existing documentation
- Add comprehensive jobs documentation covering BullMQ integration
- Add email system documentation with React Email templates
- Update contributing guide with new documentation links

## Changes
- **docs/i18n.md**: Fix translation files location (`app/locales` not `public/locales`)
- **docs/feature-flags.md**: Fix `useFlag` import path and remove outdated Cypress examples
- **docs/jobs.md**: New comprehensive documentation for background job processing
- **docs/emails.md**: New documentation for email system architecture and usage
- **docs/contributing.md**: Add links to new documentation files
