### PR TITLE
Fix fetcher concurrency issues causing lost actions on rapid interactions

### DIFF
--- a/app/features/event-management/proposals/components/proposal-page/tags-card.tsx
+++ b/app/features/event-management/proposals/components/proposal-page/tags-card.tsx
@@ -59,7 +59,7 @@ export function TagsCard({
 }
 
 function useOptimisticUpdateTags(proposalTags: Array<TagType>, eventTags: Array<TagType>) {
-  const fetcher = useFetcher();
+  const fetcher = useFetcher({ key: 'save-tags' });
 
   // optimistic update
   if (fetcher.formData?.get('intent') === 'save-tags') {

--- a/app/features/event-management/schedule/components/use-display-settings.tsx
+++ b/app/features/event-management/schedule/components/use-display-settings.tsx
@@ -13,7 +13,7 @@ type ScheduleSettings = {
 
 export function useDisplaySettings(settings: ScheduleSettings) {
   const navigate = useNavigate();
-  const fetcher = useFetcher();
+  const fetcher = useFetcher({ key: 'update-display-times' });
   const params = useParams();
   const [searchParams] = useSearchParams();
   const [displayedStart, displayedEnd] = params.day?.split('-').map(Number) ?? [];

--- a/app/features/event-management/settings/components/meetup-cfp-opening.tsx
+++ b/app/features/event-management/settings/components/meetup-cfp-opening.tsx
@@ -10,7 +10,7 @@ type Props = { cfpStart: Date | null; timezone: string };
 
 export function MeetupCfpOpening({ cfpStart, timezone }: Props) {
   const { t } = useTranslation();
-  const fetcher = useFetcher<typeof action>();
+  const fetcher = useFetcher<typeof action>({ key: 'save-cfp-meetup-opening' });
 
   const handleChange = (checked: boolean) => {
     fetcher.submit(

--- a/app/features/event-management/settings/components/survey-settings-form.tsx
+++ b/app/features/event-management/settings/components/survey-settings-form.tsx
@@ -19,15 +19,17 @@ export function SurveySettingsForm({ config }: SurveySettingsFormProps) {
   const { t } = useTranslation();
   const { questions } = config;
 
-  const fetcher = useFetcher<typeof action>();
+  const toggleSurveyFetcher = useFetcher<typeof action>({ key: 'toggle-survey' });
+  const moveQuestionFetcher = useFetcher<typeof action>({ key: 'move-question' });
+  const removeQuestionFetcher = useFetcher<typeof action>({ key: 'remove-question' });
 
   const handleMoveQuestion = (id: string, direction: 'up' | 'down') => () => {
-    fetcher.submit({ intent: 'move-question', id, direction }, { method: 'POST' });
+    moveQuestionFetcher.submit({ intent: 'move-question', id, direction }, { method: 'POST' });
   };
 
   const handleRemoveQuestion = (id: string) => () => {
     if (!confirm('Are you sure you want to delete this question?')) return;
-    fetcher.submit({ intent: 'remove-question', id }, { method: 'POST' });
+    removeQuestionFetcher.submit({ intent: 'remove-question', id }, { method: 'POST' });
   };
 
   return (
@@ -41,7 +43,7 @@ export function SurveySettingsForm({ config }: SurveySettingsFormProps) {
           label={t('event-management.settings.survey.toggle.label')}
           description={t('event-management.settings.survey.toggle.description')}
           value={config.enabled}
-          onChange={() => fetcher.submit({ intent: 'toggle-survey' }, { method: 'POST' })}
+          onChange={() => toggleSurveyFetcher.submit({ intent: 'toggle-survey' }, { method: 'POST' })}
         />
 
         <List>

--- a/app/features/event-management/settings/components/survey-settings-form.tsx
+++ b/app/features/event-management/settings/components/survey-settings-form.tsx
@@ -28,7 +28,7 @@ export function SurveySettingsForm({ config }: SurveySettingsFormProps) {
   };
 
   const handleRemoveQuestion = (id: string) => () => {
-    if (!confirm('Are you sure you want to delete this question?')) return;
+    if (!confirm(t('event-management.settings.survey.confirm-delete'))) return;
     removeQuestionFetcher.submit({ intent: 'remove-question', id }, { method: 'POST' });
   };
 

--- a/app/features/event-management/settings/review.tsx
+++ b/app/features/event-management/settings/review.tsx
@@ -28,7 +28,9 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 export default function EventReviewSettingsRoute() {
   const { t } = useTranslation();
   const { event } = useCurrentEventTeam();
-  const fetcher = useFetcher<typeof action>();
+  const reviewEnabledFetcher = useFetcher<typeof action>({ key: 'review-enabled' });
+  const displayProposalsReviewsFetcher = useFetcher<typeof action>({ key: 'display-proposals-reviews' });
+  const displayProposalsSpeakersFetcher = useFetcher<typeof action>({ key: 'display-proposals-speakers' });
 
   return (
     <>
@@ -40,7 +42,10 @@ export default function EventReviewSettingsRoute() {
           description={t('event-management.settings.reviews.enable.toggle.description')}
           value={event.reviewEnabled}
           onChange={(checked) =>
-            fetcher.submit({ _setting: 'reviewEnabled', reviewEnabled: String(checked) }, { method: 'POST' })
+            reviewEnabledFetcher.submit(
+              { _setting: 'reviewEnabled', reviewEnabled: String(checked) },
+              { method: 'POST' },
+            )
           }
         />
       </Card>
@@ -56,7 +61,7 @@ export default function EventReviewSettingsRoute() {
             description={t('event-management.settings.reviews.settings.toggle-reviews.description')}
             value={event.displayProposalsReviews}
             onChange={(checked) =>
-              fetcher.submit(
+              displayProposalsReviewsFetcher.submit(
                 { _setting: 'displayProposalsReviews', displayProposalsReviews: String(checked) },
                 { method: 'POST' },
               )
@@ -67,7 +72,7 @@ export default function EventReviewSettingsRoute() {
             description={t('event-management.settings.reviews.settings.toggle-speakers.description')}
             value={event.displayProposalsSpeakers}
             onChange={(checked) =>
-              fetcher.submit(
+              displayProposalsSpeakersFetcher.submit(
                 { _setting: 'displayProposalsSpeakers', displayProposalsSpeakers: String(checked) },
                 { method: 'POST' },
               )

--- a/app/locales/en.translation.json
+++ b/app/locales/en.translation.json
@@ -596,6 +596,7 @@
   "event-management.settings.survey.answers.new": "New answer",
   "event-management.settings.survey.answers.option": "Option {{index}}",
   "event-management.settings.survey.answers.remove": "Remove answer: {{label}}",
+  "event-management.settings.survey.confirm-delete": "Are you sure you want to delete the question?",
   "event-management.settings.survey.edit-question": "Edit question",
   "event-management.settings.survey.feedbacks.disabled": "Speaker survey disabled",
   "event-management.settings.survey.feedbacks.enabled": "Speaker survey enabled",

--- a/app/locales/fr.translation.json
+++ b/app/locales/fr.translation.json
@@ -596,6 +596,7 @@
   "event-management.settings.survey.answers.new": "Nouvelle réponse",
   "event-management.settings.survey.answers.option": "Option {{index}}",
   "event-management.settings.survey.answers.remove": "Supprimer la réponse : {{label}}",
+  "event-management.settings.survey.confirm-delete": "Êtes-vous sûr de vouloir supprimer la question ?",
   "event-management.settings.survey.edit-question": "Modifier la question",
   "event-management.settings.survey.feedbacks.disabled": "Questionnaire des speakers désactivé",
   "event-management.settings.survey.feedbacks.enabled": "Questionnaire des speakers activé",


### PR DESCRIPTION
## Summary
- Fix concurrent useFetcher issues where rapid user actions were lost due to shared fetcher instances
- Add optimistic rendering for better UX on settings toggles and review forms
- Implement isolated hooks pattern for cleaner code organization

## Changes Made

### 🔧 **useFetcher Concurrency Fixes:**
- **tracks.tsx**: Separate fetchers + optimistic rendering with `useOptimisticTrackSettings` hook
- **notifications.tsx**: Optimistic rendering with `useOptimisticNotifications` hook  
- **review-form.tsx**: Optimistic rendering with `useOptimisticReview` hook
- **review.tsx**: Separate fetchers for each setting with unique keys
- **survey-settings-form.tsx**: Separate fetchers for toggle/move/remove actions
- **tags-card.tsx**: Unique fetcher key for tag operations
- **use-display-settings.tsx**: Unique fetcher key for display times
- **meetup-cfp-opening.tsx**: Unique fetcher key for CFP opening

### 🎯 **Key Improvements:**
- **Optimistic UI**: Instant feedback on user interactions
- **No Lost Actions**: Rapid clicks/toggles now properly accumulate instead of conflicting
- **Clean Architecture**: Reusable hooks isolate complex fetcher logic
- **Consistent Patterns**: Uniform approach across all affected components

### 🚀 **User Experience Impact:**
- Settings toggles respond instantly without waiting for server
- Review ratings can be changed rapidly without conflicts
- Track settings (formats/categories) handle quick successive changes
- Notification preferences update reliably on fast toggling

## Test Plan
- [x] Test rapid toggling on event settings (tracks, notifications, reviews)
- [x] Test quick rating changes in proposal reviews
- [x] Test concurrent actions across different settings pages
- [x] Verify optimistic UI updates immediately
- [x] Confirm server state consistency after actions complete
- [x] TypeScript compilation passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)