### PR TITLE
fix(email): special char unexpectedly escaped

### DIFF
--- a/app/shared/emails/templates/organizers/proposal-confirmed.test.tsx
+++ b/app/shared/emails/templates/organizers/proposal-confirmed.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@react-email/components';
+import ProposalConfirmedEmail from './proposal-confirmed.tsx';
+
+// Mock any server-side modules that use process.env
+vi.mock('servers/environment.server.ts', () => ({
+  getSharedServerEnv: () => ({
+    APP_URL: 'http://localhost:3000',
+  }),
+  initEnv: vi.fn(),
+}));
+
+describe('Proposal Confirmed', () => {
+  describe('Special Characters Handling', () => {
+    const event = {
+      slug: 'bdx-io',
+      name: 'BDX I/O',
+      logoUrl: null,
+      emailOrganizer: 'test@bdxio.com',
+      emailNotifications: null,
+      team: { slug: 'BDX I/O' },
+    };
+    const proposal = {
+      id: '123',
+      title: 'Random Proposal w/ special characters ✨',
+      speakers: [{ name: 'Gwenaëlle B.' }],
+    };
+
+    it('Payload does not escape special characters', async () => {
+      const payload = ProposalConfirmedEmail.buildPayload({ event, proposal }, 'fr');
+
+      expect(payload.subject).toContain('BDX I/O');
+      expect(payload.from).toContain('BDX I/O');
+    });
+
+    it('HTML does not escape special characters', async () => {
+      const result = await render(<ProposalConfirmedEmail locale="fr" event={event} proposal={proposal} />);
+
+      expect(result).not.toContain('I&#x2F;O');
+      expect(result).toContain('Gwenaëlle B.');
+      expect(result).toContain('Random Proposal w/ special characters ✨');
+    });
+  });
+});

--- a/app/shared/emails/templates/organizers/proposal-confirmed.test.tsx
+++ b/app/shared/emails/templates/organizers/proposal-confirmed.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@react-email/components';
+import type { TemplateData } from './proposal-confirmed.tsx';
 import ProposalConfirmedEmail from './proposal-confirmed.tsx';
 
 // Mock any server-side modules that use process.env
@@ -11,7 +12,7 @@ vi.mock('servers/environment.server.ts', () => ({
 
 describe('Proposal Confirmed', () => {
   describe('Special Characters Handling', () => {
-    const event = {
+    const event: TemplateData['event'] = {
       slug: 'bdx-io',
       name: 'BDX I/O',
       logoUrl: null,
@@ -19,7 +20,7 @@ describe('Proposal Confirmed', () => {
       emailNotifications: null,
       team: { slug: 'BDX I/O' },
     };
-    const proposal = {
+    const proposal: TemplateData['proposal'] = {
       id: '123',
       title: 'Random Proposal w/ special characters ✨',
       speakers: [{ name: 'Gwenaëlle B.' }],
@@ -32,10 +33,13 @@ describe('Proposal Confirmed', () => {
       expect(payload.from).toContain('BDX I/O');
     });
 
-    it('HTML does not escape special characters', async () => {
-      const result = await render(<ProposalConfirmedEmail locale="fr" event={event} proposal={proposal} />);
+    it('Plain text does not escape special characters', async () => {
+      const result = await render(<ProposalConfirmedEmail locale="fr" event={event} proposal={proposal} />, {
+        plainText: true,
+      });
 
       expect(result).not.toContain('I&#x2F;O');
+      expect(result).toContain('I/O');
       expect(result).toContain('Gwenaëlle B.');
       expect(result).toContain('Random Proposal w/ special characters ✨');
     });

--- a/app/shared/emails/templates/organizers/proposal-confirmed.tsx
+++ b/app/shared/emails/templates/organizers/proposal-confirmed.tsx
@@ -6,7 +6,7 @@ import { getEmailI18n } from '~/shared/i18n/i18n.emails.ts';
 import { styles } from '../base-email.tsx';
 import BaseEventEmail from '../base-event-email.tsx';
 
-type TemplateData = {
+export type TemplateData = {
   event: {
     slug: string;
     name: string;

--- a/app/shared/emails/templates/organizers/proposal-confirmed.tsx
+++ b/app/shared/emails/templates/organizers/proposal-confirmed.tsx
@@ -51,8 +51,11 @@ ProposalConfirmedEmail.buildPayload = (data: TemplateData, locale = 'en'): Email
   const t = getEmailI18n(locale);
   return {
     template: 'organizers-proposal-confirmed',
-    subject: t('organizers.proposal-confirmed.subject', { event: data.event.name }),
-    from: t('common.email.from.event', { event: data.event.name }),
+    subject: t('organizers.proposal-confirmed.subject', {
+      event: data.event.name,
+      interpolation: { escapeValue: false },
+    }),
+    from: t('common.email.from.event', { event: data.event.name, interpolation: { escapeValue: false } }),
     to: [data.event.emailOrganizer],
     data,
     locale,

--- a/app/shared/emails/templates/organizers/proposal-declined.test.tsx
+++ b/app/shared/emails/templates/organizers/proposal-declined.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@react-email/components';
+import type { TemplateData } from './proposal-declined.tsx';
 import ProposalDeclinedEmail from './proposal-declined.tsx';
 
 // Mock any server-side modules that use process.env
@@ -11,7 +12,7 @@ vi.mock('servers/environment.server.ts', () => ({
 
 describe('Proposal Declined', () => {
   describe('Special Characters Handling', () => {
-    const event = {
+    const event: TemplateData['event'] = {
       slug: 'bdx-io',
       name: 'BDX I/O',
       logoUrl: null,
@@ -19,7 +20,7 @@ describe('Proposal Declined', () => {
       emailNotifications: null,
       team: { slug: 'BDX I/O' },
     };
-    const proposal = {
+    const proposal: TemplateData['proposal'] = {
       id: '123',
       title: 'Random Proposal w/ special characters ✨',
       speakers: [{ name: 'Gwenaëlle B.' }],
@@ -32,10 +33,13 @@ describe('Proposal Declined', () => {
       expect(payload.from).toContain('BDX I/O');
     });
 
-    it('HTML does not escape special characters', async () => {
-      const result = await render(<ProposalDeclinedEmail locale="fr" event={event} proposal={proposal} />);
+    it('Plain text does not escape special characters', async () => {
+      const result = await render(<ProposalDeclinedEmail locale="fr" event={event} proposal={proposal} />, {
+        plainText: true,
+      });
 
       expect(result).not.toContain('I&#x2F;O');
+      expect(result).toContain('I/O');
       expect(result).toContain('Gwenaëlle B.');
       expect(result).toContain('Random Proposal w/ special characters ✨');
     });

--- a/app/shared/emails/templates/organizers/proposal-declined.test.tsx
+++ b/app/shared/emails/templates/organizers/proposal-declined.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@react-email/components';
+import ProposalDeclinedEmail from './proposal-declined.tsx';
+
+// Mock any server-side modules that use process.env
+vi.mock('servers/environment.server.ts', () => ({
+  getSharedServerEnv: () => ({
+    APP_URL: 'http://localhost:3000',
+  }),
+  initEnv: vi.fn(),
+}));
+
+describe('Proposal Declined', () => {
+  describe('Special Characters Handling', () => {
+    const event = {
+      slug: 'bdx-io',
+      name: 'BDX I/O',
+      logoUrl: null,
+      emailOrganizer: 'test@bdxio.com',
+      emailNotifications: null,
+      team: { slug: 'BDX I/O' },
+    };
+    const proposal = {
+      id: '123',
+      title: 'Random Proposal w/ special characters ✨',
+      speakers: [{ name: 'Gwenaëlle B.' }],
+    };
+
+    it('Payload does not escape special characters', async () => {
+      const payload = ProposalDeclinedEmail.buildPayload({ event, proposal }, 'fr');
+
+      expect(payload.subject).toContain('BDX I/O');
+      expect(payload.from).toContain('BDX I/O');
+    });
+
+    it('HTML does not escape special characters', async () => {
+      const result = await render(<ProposalDeclinedEmail locale="fr" event={event} proposal={proposal} />);
+
+      expect(result).not.toContain('I&#x2F;O');
+      expect(result).toContain('Gwenaëlle B.');
+      expect(result).toContain('Random Proposal w/ special characters ✨');
+    });
+  });
+});

--- a/app/shared/emails/templates/organizers/proposal-declined.tsx
+++ b/app/shared/emails/templates/organizers/proposal-declined.tsx
@@ -51,8 +51,11 @@ ProposalDeclinedEmail.buildPayload = (data: TemplateData, locale = 'en'): EmailP
   const t = getEmailI18n(locale);
   return {
     template: 'organizers-proposal-declined',
-    subject: t('organizers.proposal-declined.subject', { event: data.event.name }),
-    from: t('common.email.from.event', { event: data.event.name }),
+    subject: t('organizers.proposal-declined.subject', {
+      event: data.event.name,
+      interpolation: { escapeValue: false },
+    }),
+    from: t('common.email.from.event', { event: data.event.name, interpolation: { escapeValue: false } }),
     to: [data.event.emailOrganizer],
     data,
     locale,

--- a/app/shared/emails/templates/organizers/proposal-declined.tsx
+++ b/app/shared/emails/templates/organizers/proposal-declined.tsx
@@ -6,7 +6,7 @@ import { getEmailI18n } from '~/shared/i18n/i18n.emails.ts';
 import { styles } from '../base-email.tsx';
 import BaseEventEmail from '../base-event-email.tsx';
 
-type TemplateData = {
+export type TemplateData = {
   event: {
     slug: string;
     name: string;

--- a/app/shared/emails/templates/organizers/proposal-submitted.test.tsx
+++ b/app/shared/emails/templates/organizers/proposal-submitted.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@react-email/components';
+import ProposalSubmittedEmail from './proposal-submitted.tsx';
+
+// Mock any server-side modules that use process.env
+vi.mock('servers/environment.server.ts', () => ({
+  getSharedServerEnv: () => ({
+    APP_URL: 'http://localhost:3000',
+  }),
+  initEnv: vi.fn(),
+}));
+
+describe('Proposal Submitted', () => {
+  describe('Special Characters Handling', () => {
+    const event = {
+      slug: 'bdx-io',
+      name: 'BDX I/O',
+      logoUrl: null,
+      emailOrganizer: 'test@bdxio.com',
+      emailNotifications: null,
+      team: { slug: 'BDX I/O' },
+    };
+    const proposal = {
+      id: '123',
+      title: 'Random Proposal w/ special characters ✨',
+      speakers: [{ name: 'Gwenaëlle B.' }],
+    };
+
+    it('Payload does not escape special characters', async () => {
+      const payload = ProposalSubmittedEmail.buildPayload({ event, proposal }, 'fr');
+
+      expect(payload.subject).toContain('BDX I/O');
+      expect(payload.from).toContain('BDX I/O');
+    });
+
+    it('HTML does not escape special characters', async () => {
+      const result = await render(<ProposalSubmittedEmail locale="fr" event={event} proposal={proposal} />);
+
+      expect(result).not.toContain('I&#x2F;O');
+      expect(result).toContain('Gwenaëlle B.');
+      expect(result).toContain('Random Proposal w/ special characters ✨');
+    });
+  });
+});

--- a/app/shared/emails/templates/organizers/proposal-submitted.tsx
+++ b/app/shared/emails/templates/organizers/proposal-submitted.tsx
@@ -51,8 +51,11 @@ ProposalSubmittedEmail.buildPayload = (data: TemplateData, locale = 'en'): Email
   const t = getEmailI18n(locale);
   return {
     template: 'organizers-proposal-submitted',
-    subject: t('organizers.proposal-submitted.subject', { event: data.event.name }),
-    from: t('common.email.from.event', { event: data.event.name }),
+    subject: t('organizers.proposal-submitted.subject', {
+      event: data.event.name,
+      interpolation: { escapeValue: false },
+    }),
+    from: t('common.email.from.event', { event: data.event.name, interpolation: { escapeValue: false } }),
     to: [data.event.emailOrganizer],
     data,
     locale,

--- a/app/shared/emails/templates/organizers/proposal-submitted.tsx
+++ b/app/shared/emails/templates/organizers/proposal-submitted.tsx
@@ -6,7 +6,7 @@ import { getEmailI18n } from '~/shared/i18n/i18n.emails.ts';
 import { styles } from '../base-email.tsx';
 import BaseEventEmail from '../base-event-email.tsx';
 
-type TemplateData = {
+export type TemplateData = {
   event: {
     slug: string;
     name: string;

--- a/app/shared/emails/templates/speakers/proposal-accepted.test.tsx
+++ b/app/shared/emails/templates/speakers/proposal-accepted.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@react-email/components';
-import type { TemplateData } from './proposal-submitted.tsx';
-import ProposalSubmittedEmail from './proposal-submitted.tsx';
+import type { TemplateData } from './proposal-accepted.tsx';
+import ProposalAcceptedEmail from './proposal-accepted.tsx';
 
 // Mock any server-side modules that use process.env
 vi.mock('servers/environment.server.ts', () => ({
@@ -10,37 +10,36 @@ vi.mock('servers/environment.server.ts', () => ({
   initEnv: vi.fn(),
 }));
 
-describe('Proposal Submitted', () => {
+describe('Proposal Accepted', () => {
   describe('Special Characters Handling', () => {
     const event: TemplateData['event'] = {
+      id: 'bdx-io',
       slug: 'bdx-io',
       name: 'BDX I/O',
       logoUrl: null,
-      emailOrganizer: 'test@bdxio.com',
-      emailNotifications: null,
-      team: { slug: 'BDX I/O' },
     };
     const proposal: TemplateData['proposal'] = {
       id: '123',
       title: 'Random Proposal w/ special characters ✨',
-      speakers: [{ name: 'Gwenaëlle B.' }],
+      formats: [{ name: 'Format 1' }, { name: 'Format 2' }],
+      speakers: [{ email: 'test@test.com', locale: 'fr' }],
     };
 
     it('Payload does not escape special characters', async () => {
-      const payload = ProposalSubmittedEmail.buildPayload({ event, proposal }, 'fr');
+      const payload = ProposalAcceptedEmail.buildPayload({ event, proposal }, 'fr');
 
       expect(payload.subject).toContain('BDX I/O');
       expect(payload.from).toContain('BDX I/O');
     });
 
     it('Plain text does not escape special characters', async () => {
-      const result = await render(<ProposalSubmittedEmail locale="fr" event={event} proposal={proposal} />, {
-        plainText: true,
-      });
+      const result = await render(
+        <ProposalAcceptedEmail locale="fr" event={event} proposal={proposal} customization={null} preview={false} />,
+        { plainText: true },
+      );
 
       expect(result).not.toContain('I&#x2F;O');
       expect(result).toContain('I/O');
-      expect(result).toContain('Gwenaëlle B.');
       expect(result).toContain('Random Proposal w/ special characters ✨');
     });
   });

--- a/app/shared/emails/templates/speakers/proposal-accepted.tsx
+++ b/app/shared/emails/templates/speakers/proposal-accepted.tsx
@@ -7,7 +7,7 @@ import { getEmailI18n } from '~/shared/i18n/i18n.emails.ts';
 import { styles } from '../base-email.tsx';
 import BaseEventEmail from '../base-event-email.tsx';
 
-type TemplateData = {
+export type TemplateData = {
   event: { id: string; slug: string; name: string; logoUrl: string | null };
   proposal: {
     id: string;
@@ -29,7 +29,9 @@ export default function ProposalAcceptedEmail({ event, proposal, locale, customi
       {customization?.content ? (
         <EmailMarkdown>{customization.content.replaceAll('{{proposal}}', proposal.title)}</EmailMarkdown>
       ) : (
-        <Text>{t('speakers.proposal-accepted.body.text1', { event: event.name })}</Text>
+        <Text>
+          {t('speakers.proposal-accepted.body.text1', { event: event.name, interpolation: { escapeValue: false } })}
+        </Text>
       )}
 
       <Section className={styles.card}>
@@ -60,8 +62,8 @@ ProposalAcceptedEmail.buildPayload = (data: TemplateData, localeOverride?: strin
 
   return {
     template: 'speakers-proposal-accepted',
-    subject: t('speakers.proposal-accepted.subject', { event: data.event.name }),
-    from: t('common.email.from.event', { event: data.event.name }),
+    subject: t('speakers.proposal-accepted.subject', { event: data.event.name, interpolation: { escapeValue: false } }),
+    from: t('common.email.from.event', { event: data.event.name, interpolation: { escapeValue: false } }),
     to: data.proposal.speakers.map((speaker) => speaker.email),
     data,
     locale,

--- a/app/shared/emails/templates/speakers/proposal-rejected.test.tsx
+++ b/app/shared/emails/templates/speakers/proposal-rejected.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@react-email/components';
-import type { TemplateData } from './proposal-submitted.tsx';
-import ProposalSubmittedEmail from './proposal-submitted.tsx';
+import type { TemplateData } from './proposal-rejected.tsx';
+import ProposalRejectedEmail from './proposal-rejected.tsx';
 
 // Mock any server-side modules that use process.env
 vi.mock('servers/environment.server.ts', () => ({
@@ -10,37 +10,33 @@ vi.mock('servers/environment.server.ts', () => ({
   initEnv: vi.fn(),
 }));
 
-describe('Proposal Submitted', () => {
+describe('Proposal Rejected', () => {
   describe('Special Characters Handling', () => {
     const event: TemplateData['event'] = {
-      slug: 'bdx-io',
+      id: 'bdx-io',
       name: 'BDX I/O',
       logoUrl: null,
-      emailOrganizer: 'test@bdxio.com',
-      emailNotifications: null,
-      team: { slug: 'BDX I/O' },
     };
     const proposal: TemplateData['proposal'] = {
-      id: '123',
       title: 'Random Proposal w/ special characters ✨',
-      speakers: [{ name: 'Gwenaëlle B.' }],
+      speakers: [{ email: 'test@test.com', locale: 'fr' }],
     };
 
     it('Payload does not escape special characters', async () => {
-      const payload = ProposalSubmittedEmail.buildPayload({ event, proposal }, 'fr');
+      const payload = ProposalRejectedEmail.buildPayload({ event, proposal }, 'fr');
 
       expect(payload.subject).toContain('BDX I/O');
       expect(payload.from).toContain('BDX I/O');
     });
 
     it('Plain text does not escape special characters', async () => {
-      const result = await render(<ProposalSubmittedEmail locale="fr" event={event} proposal={proposal} />, {
-        plainText: true,
-      });
+      const result = await render(
+        <ProposalRejectedEmail locale="fr" event={event} proposal={proposal} customization={null} preview={false} />,
+        { plainText: true },
+      );
 
       expect(result).not.toContain('I&#x2F;O');
       expect(result).toContain('I/O');
-      expect(result).toContain('Gwenaëlle B.');
       expect(result).toContain('Random Proposal w/ special characters ✨');
     });
   });

--- a/app/shared/emails/templates/speakers/proposal-rejected.tsx
+++ b/app/shared/emails/templates/speakers/proposal-rejected.tsx
@@ -6,7 +6,7 @@ import { getEmailI18n } from '~/shared/i18n/i18n.emails.ts';
 import { styles } from '../base-email.tsx';
 import BaseEventEmail from '../base-event-email.tsx';
 
-type TemplateData = {
+export type TemplateData = {
   event: { id: string; name: string; logoUrl: string | null };
   proposal: { title: string; speakers: Array<{ email: string; locale: string }> };
 };
@@ -24,7 +24,13 @@ export default function ProposalRejectedEmail({ event, proposal, locale, customi
         <EmailMarkdown>{customization.content.replaceAll('{{proposal}}', proposal.title)}</EmailMarkdown>
       ) : (
         <>
-          <Text>{t('speakers.proposal-rejected.body.text1', { event: event.name, proposal: proposal.title })}</Text>
+          <Text>
+            {t('speakers.proposal-rejected.body.text1', {
+              event: event.name,
+              proposal: proposal.title,
+              interpolation: { escapeValue: false },
+            })}
+          </Text>
 
           <Text>{t('speakers.proposal-rejected.body.text2')}</Text>
 
@@ -43,8 +49,8 @@ ProposalRejectedEmail.buildPayload = (data: TemplateData, localeOverride?: strin
 
   return {
     template: 'speakers-proposal-rejected',
-    subject: t('speakers.proposal-rejected.subject', { event: data.event.name }),
-    from: t('common.email.from.event', { event: data.event.name }),
+    subject: t('speakers.proposal-rejected.subject', { event: data.event.name, interpolation: { escapeValue: false } }),
+    from: t('common.email.from.event', { event: data.event.name, interpolation: { escapeValue: false } }),
     to: data.proposal.speakers.map((speaker) => speaker.email),
     data,
     locale,

--- a/app/shared/emails/templates/speakers/proposal-submitted.test.tsx
+++ b/app/shared/emails/templates/speakers/proposal-submitted.test.tsx
@@ -13,17 +13,13 @@ vi.mock('servers/environment.server.ts', () => ({
 describe('Proposal Submitted', () => {
   describe('Special Characters Handling', () => {
     const event: TemplateData['event'] = {
-      slug: 'bdx-io',
+      id: 'bdx-io',
       name: 'BDX I/O',
       logoUrl: null,
-      emailOrganizer: 'test@bdxio.com',
-      emailNotifications: null,
-      team: { slug: 'BDX I/O' },
     };
     const proposal: TemplateData['proposal'] = {
-      id: '123',
       title: 'Random Proposal w/ special characters ✨',
-      speakers: [{ name: 'Gwenaëlle B.' }],
+      speakers: [{ email: 'test@test.com', locale: 'fr' }],
     };
 
     it('Payload does not escape special characters', async () => {
@@ -34,13 +30,13 @@ describe('Proposal Submitted', () => {
     });
 
     it('Plain text does not escape special characters', async () => {
-      const result = await render(<ProposalSubmittedEmail locale="fr" event={event} proposal={proposal} />, {
-        plainText: true,
-      });
+      const result = await render(
+        <ProposalSubmittedEmail locale="fr" event={event} proposal={proposal} customization={null} preview={false} />,
+        { plainText: true },
+      );
 
       expect(result).not.toContain('I&#x2F;O');
       expect(result).toContain('I/O');
-      expect(result).toContain('Gwenaëlle B.');
       expect(result).toContain('Random Proposal w/ special characters ✨');
     });
   });

--- a/app/shared/emails/templates/speakers/proposal-submitted.tsx
+++ b/app/shared/emails/templates/speakers/proposal-submitted.tsx
@@ -7,7 +7,7 @@ import { getEmailI18n } from '~/shared/i18n/i18n.emails.ts';
 import { styles } from '../base-email.tsx';
 import BaseEventEmail from '../base-event-email.tsx';
 
-type TemplateData = {
+export type TemplateData = {
   event: { id: string; name: string; logoUrl: string | null };
   proposal: { title: string; speakers: Array<{ email: string; locale: string }> };
 };
@@ -25,7 +25,13 @@ export default function ProposalSubmittedEmail({ event, proposal, locale, custom
         <EmailMarkdown>{customization.content.replaceAll('{{proposal}}', proposal.title)}</EmailMarkdown>
       ) : (
         <>
-          <Text>{t('speakers.proposal-submitted.body.text1', { proposal: proposal.title, event: event.name })}</Text>
+          <Text>
+            {t('speakers.proposal-submitted.body.text1', {
+              proposal: proposal.title,
+              event: event.name,
+              interpolation: { escapeValue: false },
+            })}
+          </Text>
 
           <Text>{t('speakers.proposal-submitted.body.text2')}</Text>
         </>
@@ -46,8 +52,11 @@ ProposalSubmittedEmail.buildPayload = (data: TemplateData, localeOverride?: stri
 
   return {
     template: 'speakers-proposal-submitted',
-    subject: t('speakers.proposal-submitted.subject', { event: data.event.name }),
-    from: t('common.email.from.event', { event: data.event.name }),
+    subject: t('speakers.proposal-submitted.subject', {
+      event: data.event.name,
+      interpolation: { escapeValue: false },
+    }),
+    from: t('common.email.from.event', { event: data.event.name, interpolation: { escapeValue: false } }),
     to: data.proposal.speakers.map((speaker) => speaker.email),
     data,
     locale,


### PR DESCRIPTION
Fixes #525 

- Add the option to not interpolate the string injected, avoiding the escaping of special characters on **subject**  and **from** (both coming from the event name property)
- Tests created -- I've added one test per email type in order to provide the possibility to add more detailed tests case later on. This helped ensuring all the templates at the destination to users were fixed: _templates/speakers_ and _templates/organizers_. 

The atomic testing approach might seem opinionated and going against the philosophy around what you were trying to push around testing, let me know if you would prefer another way to implement it 😄 
