### PR TITLE
feat: add submission date on JSON export of proposals

### DIFF
--- a/app/features/event-management/proposals-export/services/proposals-export.server.test.ts
+++ b/app/features/event-management/proposals-export/services/proposals-export.server.test.ts
@@ -86,6 +86,7 @@ describe('ProposalsExport', () => {
             id: proposal.id,
             proposalNumber: proposal.proposalNumber,
             title: proposal.title,
+            submittedAt: proposal.submittedAt,
             deliberationStatus: proposal.deliberationStatus,
             confirmationStatus: proposal.confirmationStatus,
             publicationStatus: proposal.publicationStatus,

--- a/app/features/event-management/proposals-export/services/proposals-export.server.ts
+++ b/app/features/event-management/proposals-export/services/proposals-export.server.ts
@@ -59,6 +59,7 @@ export class ProposalsExport {
           proposalNumber: proposal.proposalNumber,
           title: proposal.title,
           abstract: proposal.abstract,
+          submittedAt: proposal.submittedAt,
           deliberationStatus: proposal.deliberationStatus,
           confirmationStatus: proposal.confirmationStatus,
           publicationStatus: proposal.publicationStatus,


### PR DESCRIPTION
## Why

I'd like to have the submission date exported in the JSON API. I think it could be used in many use cases such as sorting and filtering. It might be very usefull for Meetup events.

## How

Just add an attribute `submittedAt` and map it to the already stored proposal `submittedAt`.