### PR TITLE
feat: add per-event toggle to hide spoken-languages question on talk submission

### DIFF
--- a/app/features/event-management/services/event-fetcher.server.ts
+++ b/app/features/event-management/services/event-fetcher.server.ts
@@ -50,6 +50,7 @@ export class EventFetcher {
       formatsAllowMultiple: fullEvent.formatsAllowMultiple,
       categoriesRequired: fullEvent.categoriesRequired,
       categoriesAllowMultiple: fullEvent.categoriesAllowMultiple,
+      languageEnabled: fullEvent.languageEnabled,
       emailOrganizer: fullEvent.emailOrganizer,
       emailNotifications: (fullEvent.emailNotifications || []) as EventEmailNotificationsKeys,
       slackWebhookUrl: fullEvent.slackWebhookUrl,

--- a/app/features/event-management/settings/cfp.tsx
+++ b/app/features/event-management/settings/cfp.tsx
@@ -40,6 +40,12 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
       await event.update(result.value);
       break;
     }
+    case 'toggle-language-enabled': {
+      await event.update({
+        languageEnabled: form.get('languageEnabled') === 'true',
+      });
+      break;
+    }
   }
 
   return toast('success', i18n.t('event-management.settings.cfp.feedbacks.updated'));
@@ -61,7 +67,12 @@ export default function EventCfpSettingsRoute({ actionData: errors }: Route.Comp
         <MeetupCfpOpening cfpStart={event.cfpStart} timezone={event.timezone} />
       )}
 
-      <CommonCfpSetting maxProposals={event.maxProposals} codeOfConductUrl={event.codeOfConductUrl} errors={errors} />
+      <CommonCfpSetting
+        maxProposals={event.maxProposals}
+        codeOfConductUrl={event.codeOfConductUrl}
+        languageEnabled={event.languageEnabled}
+        errors={errors}
+      />
     </>
   );
 }

--- a/app/features/event-management/settings/components/common-cfp-setting.tsx
+++ b/app/features/event-management/settings/components/common-cfp-setting.tsx
@@ -1,52 +1,77 @@
 import { useTranslation } from 'react-i18next';
-import { Form } from 'react-router';
+import { Form, useFetcher } from 'react-router';
 import type { SubmissionErrors } from '~/shared/types/errors.types.ts';
 import { Button } from '~/design-system/button.tsx';
 import { Input } from '~/design-system/forms/input.tsx';
+import { ToggleGroup } from '~/design-system/forms/toggles.tsx';
 import { Card } from '~/design-system/layouts/card.tsx';
 import { H2 } from '~/design-system/typography.tsx';
 
 type Props = {
   maxProposals: number | null;
   codeOfConductUrl: string | null;
+  languageEnabled: boolean;
   errors: SubmissionErrors;
 };
 
-export function CommonCfpSetting({ maxProposals, codeOfConductUrl, errors }: Props) {
+export function CommonCfpSetting({ maxProposals, codeOfConductUrl, languageEnabled, errors }: Props) {
   const { t } = useTranslation();
+  const languageFetcher = useFetcher({ key: 'toggle-language-enabled' });
+
+  const optimisticLanguageEnabled =
+    languageFetcher.formData?.get('intent') === 'toggle-language-enabled'
+      ? languageFetcher.formData.get('languageEnabled') === 'true'
+      : languageEnabled;
+
   return (
-    <Card as="section">
-      <Card.Title>
-        <H2>{t('event-management.settings.cfp.preferences.heading')}</H2>
-      </Card.Title>
+    <>
+      <Card as="section">
+        <Card.Title>
+          <H2>{t('event-management.settings.cfp.preferences.heading')}</H2>
+        </Card.Title>
 
-      <Form method="POST">
-        <Card.Content>
-          <Input
-            name="maxProposals"
-            label={t('event-management.settings.cfp.preferences.max-proposals.label')}
-            description={t('event-management.settings.cfp.preferences.max-proposals.description')}
-            type="number"
-            defaultValue={maxProposals || ''}
-            min={1}
-            autoComplete="off"
-            error={errors?.maxProposals}
-          />
-          <Input
-            name="codeOfConductUrl"
-            label={t('event-management.settings.cfp.preferences.coc-url.label')}
-            description={t('event-management.settings.cfp.preferences.coc-url.description')}
-            defaultValue={codeOfConductUrl || ''}
-            error={errors?.codeOfConductUrl}
-          />
-        </Card.Content>
+        <Form method="POST">
+          <Card.Content>
+            <Input
+              name="maxProposals"
+              label={t('event-management.settings.cfp.preferences.max-proposals.label')}
+              description={t('event-management.settings.cfp.preferences.max-proposals.description')}
+              type="number"
+              defaultValue={maxProposals || ''}
+              min={1}
+              autoComplete="off"
+              error={errors?.maxProposals}
+            />
+            <Input
+              name="codeOfConductUrl"
+              label={t('event-management.settings.cfp.preferences.coc-url.label')}
+              description={t('event-management.settings.cfp.preferences.coc-url.description')}
+              defaultValue={codeOfConductUrl || ''}
+              error={errors?.codeOfConductUrl}
+            />
+          </Card.Content>
 
-        <Card.Actions>
-          <Button name="intent" value="save-cfp-preferences">
-            {t('event-management.settings.cfp.preferences.submit')}
-          </Button>
-        </Card.Actions>
-      </Form>
-    </Card>
+          <Card.Actions>
+            <Button name="intent" value="save-cfp-preferences">
+              {t('event-management.settings.cfp.preferences.submit')}
+            </Button>
+          </Card.Actions>
+        </Form>
+      </Card>
+
+      <Card as="section" p={8} className="space-y-8">
+        <ToggleGroup
+          label={t('event-management.settings.cfp.preferences.language-enabled.label')}
+          description={t('event-management.settings.cfp.preferences.language-enabled.description')}
+          value={optimisticLanguageEnabled}
+          onChange={(checked) =>
+            languageFetcher.submit(
+              { intent: 'toggle-language-enabled', languageEnabled: String(checked) },
+              { method: 'POST' },
+            )
+          }
+        />
+      </Card>
+    </>
   );
 }

--- a/app/features/event-participation/cfp-submission/2-talk.tsx
+++ b/app/features/event-participation/cfp-submission/2-talk.tsx
@@ -8,6 +8,7 @@ import { Card } from '~/design-system/layouts/card.tsx';
 import { Page } from '~/design-system/layouts/page.tsx';
 import { H2 } from '~/design-system/typography.tsx';
 import { TalkSubmission } from '~/features/event-participation/cfp-submission/services/talk-submission.server.ts';
+import { useCurrentEvent } from '~/features/event-participation/event-page-context.tsx';
 import { TalkForm } from '~/features/speaker/talk-library/components/talk-forms/talk-form.tsx';
 import { TalksLibrary } from '~/features/speaker/talk-library/services/talks-library.server.ts';
 import { RequireAuthContext } from '~/shared/authentication/auth.middleware.ts';
@@ -44,6 +45,7 @@ export default function SubmissionTalkRoute({ loaderData: talk, actionData: erro
   const { t } = useTranslation();
   const formId = useId();
   const { previousPath } = useSubmissionNavigation();
+  const { languageEnabled } = useCurrentEvent();
 
   return (
     <Page>
@@ -53,7 +55,7 @@ export default function SubmissionTalkRoute({ loaderData: talk, actionData: erro
         </Card.Title>
 
         <Card.Content>
-          <TalkForm id={formId} initialValues={talk} errors={errors} />
+          <TalkForm id={formId} initialValues={talk} languageEnabled={languageEnabled} errors={errors} />
         </Card.Content>
 
         <Card.Actions>

--- a/app/features/event-participation/event-page/services/event-page.server.ts
+++ b/app/features/event-participation/event-page/services/event-page.server.ts
@@ -62,6 +62,7 @@ export class EventPage {
       })),
       categoriesRequired: event.categoriesRequired,
       categoriesAllowMultiple: event.categoriesAllowMultiple,
+      languageEnabled: event.languageEnabled,
       speakersConversationEnabled: event.speakersConversationEnabled,
     };
   }

--- a/app/features/speaker/talk-library/components/talk-forms/talk-form-drawer.tsx
+++ b/app/features/speaker/talk-library/components/talk-forms/talk-form-drawer.tsx
@@ -23,6 +23,7 @@ type TalkEditProps = {
     categories?: Array<{ id: string; name: string; description: string | null }>;
     categoriesRequired?: boolean;
     categoriesAllowMultiple?: boolean;
+    languageEnabled?: boolean;
   };
   errors: SubmissionErrors;
 };
@@ -64,6 +65,7 @@ export function TalkEditDrawer({ initialValues, event, errors, open, onClose }: 
           formatsAllowMultiple={event?.formatsAllowMultiple}
           categoriesRequired={event?.categoriesRequired}
           categoriesAllowMultiple={event?.categoriesAllowMultiple}
+          languageEnabled={event?.languageEnabled}
           errors={errors}
           onSubmit={onClose}
         />

--- a/app/features/speaker/talk-library/components/talk-forms/talk-form.test.tsx
+++ b/app/features/speaker/talk-library/components/talk-forms/talk-form.test.tsx
@@ -61,6 +61,18 @@ describe('TalkForm', () => {
     await expect.element(page.getByLabelText('Backend')).toBeInTheDocument();
   });
 
+  it('hides languages field when languageEnabled is false', async () => {
+    await renderComponent({ languageEnabled: false });
+
+    await expect.element(page.getByLabelText(/languages/i)).not.toBeInTheDocument();
+  });
+
+  it('shows languages field when languageEnabled is true', async () => {
+    await renderComponent({ languageEnabled: true });
+
+    await expect.element(page.getByLabelText(/languages/i)).toBeInTheDocument();
+  });
+
   it('displays initial values correctly', async () => {
     const initialValues = {
       title: 'Test Talk Title',

--- a/app/features/speaker/talk-library/components/talk-forms/talk-form.tsx
+++ b/app/features/speaker/talk-library/components/talk-forms/talk-form.tsx
@@ -28,6 +28,7 @@ type Props = {
   categories?: Array<{ id: string; name: string; description: string | null }>;
   categoriesRequired?: boolean;
   categoriesAllowMultiple?: boolean;
+  languageEnabled?: boolean;
   errors: SubmissionErrors;
   onSubmit?: VoidFunction;
 };
@@ -41,6 +42,7 @@ export function TalkForm({
   categories,
   categoriesRequired,
   categoriesAllowMultiple,
+  languageEnabled = true,
   errors,
   onSubmit,
 }: Props) {
@@ -79,16 +81,18 @@ export function TalkForm({
         ))}
       </FieldsetGroup>
 
-      <MultiSelect
-        name="languages"
-        label={t('talk.languages')}
-        placeholder={t('talk.languages.placeholder')}
-        options={LANGUAGES.map((lang) => ({
-          value: lang,
-          label: `${t(`common.languages.${lang}.flag`)} ${t(`common.languages.${lang}.label`)}`,
-        }))}
-        defaultValues={initialValues?.languages ?? []}
-      />
+      {languageEnabled && (
+        <MultiSelect
+          name="languages"
+          label={t('talk.languages')}
+          placeholder={t('talk.languages.placeholder')}
+          options={LANGUAGES.map((lang) => ({
+            value: lang,
+            label: `${t(`common.languages.${lang}.flag`)} ${t(`common.languages.${lang}.label`)}`,
+          }))}
+          defaultValues={initialValues?.languages ?? []}
+        />
+      )}
 
       {hasFormats && (
         <FormatsForm

--- a/app/locales/en.translation.json
+++ b/app/locales/en.translation.json
@@ -556,6 +556,8 @@
   "event-management.settings.cfp.preferences.coc-url.description": "Optional. Speakers will be required to agree to the code of conduct before submitting their proposal.",
   "event-management.settings.cfp.preferences.coc-url.label": "Code of conduct URL",
   "event-management.settings.cfp.preferences.heading": "Call for papers preferences",
+  "event-management.settings.cfp.preferences.language-enabled.description": "When enabled, speakers can select the spoken languages for their talk during submission.",
+  "event-management.settings.cfp.preferences.language-enabled.label": "Ask spoken languages for talks",
   "event-management.settings.cfp.preferences.max-proposals.description": "Optional. Limits the number of proposals a speaker can submit to the event.",
   "event-management.settings.cfp.preferences.max-proposals.label": "Maximum of proposals per speaker",
   "event-management.settings.cfp.preferences.submit": "Update CFP preferences",

--- a/app/locales/fr.translation.json
+++ b/app/locales/fr.translation.json
@@ -554,6 +554,8 @@
   "event-management.settings.cfp.preferences.coc-url.description": "Facultatif. Les speakers devront accepter le code de conduite avant de soumettre leur proposition.",
   "event-management.settings.cfp.preferences.coc-url.label": "URL du code de conduite",
   "event-management.settings.cfp.preferences.heading": "Préférences du call for papers",
+  "event-management.settings.cfp.preferences.language-enabled.description": "Lorsque cette option est activée, les speakers peuvent sélectionner les langues parlées pour leur talk lors de la soumission.",
+  "event-management.settings.cfp.preferences.language-enabled.label": "Demander les langues parlées pour les talks",
   "event-management.settings.cfp.preferences.max-proposals.description": "Facultatif. Limite le nombre de propositions qu'un speaker peut soumettre à l'événement.",
   "event-management.settings.cfp.preferences.max-proposals.label": "Maximum de propositions par speaker",
   "event-management.settings.cfp.preferences.submit": "Mettre à jour les préférences du CFP",

--- a/prisma/migrations/20260206100000_add_language_enabled_to_event/migration.sql
+++ b/prisma/migrations/20260206100000_add_language_enabled_to_event/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "events" ADD COLUMN "languageEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,7 @@ model Event {
   categories                  EventCategory[]
   categoriesRequired          Boolean                   @default(false)
   categoriesAllowMultiple     Boolean                   @default(false)
+  languageEnabled             Boolean                   @default(true)
   maxProposals                Int?
   creatorId                   String
   creator                     User                      @relation(fields: [creatorId], references: [id])


### PR DESCRIPTION
## Summary

Hello!

This pull request introduces a **per-event setting** that allows organizers to hide the **“spoken languages”** question from the talk submission form as I suggested in this feature request: https://github.com/conference-hall/conference-hall/discussions/673

---

## Key changes

### Database
- Add `languageEnabled` boolean to `Event` (default: `true`)
- Migration SQL:  
  `prisma/migrations/20260206100000_add_language_enabled_to_event/migration.sql`

### Backend
- Expose `languageEnabled` in `EventFetcher` (`event-fetcher.server.ts`)
- Expose `languageEnabled` in `EventPage` (`event-page.server.ts`)
- Add handler in CFP settings action to toggle `languageEnabled` (`cfp.tsx`)

### Frontend
- Add CFP toggle UI for the setting (`common-cfp-setting.tsx`)
- Add `languageEnabled` prop to `TalkForm` and conditionally render the languages `MultiSelect` (`talk-form.tsx`)
- Pass the flag through the talk edit drawer and CFP submission flow  
  (`talk-form-drawer.tsx`, `2-talk.tsx`)

### i18n
- Add translations for the setting label and description:
  - English (`en.translation.json`)
  - French (`fr.translation.json`)

### Tests
- Add visibility assertions to talk form tests (`talk-form.test.tsx`)

---

## Why

Some events require enforcing a single language (e.g. English), or simply do not want speakers to select spoken languages.

This feature lets organizers decide **per event** whether the “spoken languages” question should be displayed during talk submission.

---

## Migration

Apply the migration to add the new column to your database.

> Note: A raw SQL migration file is included under  
> `prisma/migrations/20260206100000_add_language_enabled_to_event/migration.sql`.  
> If preferred, the migration can be regenerated locally using Prisma.

---

## How to validate locally

1. Apply the database migration (see **Migration** section).
2. Start the application.
3. Go to **Event → Settings → CFP**.
4. Verify the toggle **“Ask spoken languages for talks”** is visible.

**Toggle OFF**
- Create or edit a talk under that event.
- The **Languages MultiSelect** should be hidden.

**Toggle ON**
- The **Languages MultiSelect** should reappear.

5. Run unit tests and e2e tests.

---

## Risks / Review notes

- The migration was added manually — please verify it matches your DB conventions.
- Review any validation or API code that assumes `languages` is always present and ensure it tolerates its absence.
  - In particular, confirm `TalkSaveSchema` and API consumers behave correctly when `languages` is omitted.
- Please double-check `event-settings.schema.server.ts` for any unintended formatting or content changes.
- Tests cover visibility changes, but the full test suite and e2e should be run to detect regressions.

---

## Notes

I’m not 100% sure everything is fully covered, please thoroughly review all my code 🙏  (the DB migration, validation logic, and any code consuming `languages`, etc.).

Happy to iterate if you want to adjust scope or defaults.

Thanks again for this tool!