### PR TITLE
Update date display

### DIFF
--- a/app/shared/datetimes/datetimes.test.ts
+++ b/app/shared/datetimes/datetimes.test.ts
@@ -139,6 +139,13 @@ describe('datetimes', () => {
       const formatted = formatDateRange(startDate, endDate, { format: 'medium', locale: 'en' });
       expect(formatted).toEqual('Feb 26 / Mar 5, 2020');
     });
+
+    it('formats same day with different Date object instances', async () => {
+      const startDate = new Date('2020-02-26T00:00:00.000Z');
+      const endDate = new Date('2020-02-26T00:00:00.000Z');
+      const formatted = formatDateRange(startDate, endDate, { format: 'long', locale: 'en' });
+      expect(formatted).toEqual('February 26, 2020');
+    });
   });
 
   describe('#formatTime', () => {

--- a/app/shared/datetimes/datetimes.ts
+++ b/app/shared/datetimes/datetimes.ts
@@ -4,6 +4,7 @@ import {
   differenceInMinutes,
   formatDuration,
   intervalToDuration,
+  isSameDay,
   setMinutes,
   startOfDay,
 } from 'date-fns';
@@ -29,17 +30,17 @@ const DATETIME_FORMATS: Record<FormatType, Intl.DateTimeFormatOptions> = {
 };
 
 const DATE_FORMATS: Record<FormatType, Intl.DateTimeFormatOptions> = {
-  // 10/1/2023
+  // 10/01/2023
   short: { day: '2-digit', month: '2-digit', year: 'numeric' },
   // 1 Oct 2023
   medium: { day: 'numeric', month: 'short', year: 'numeric' },
   // 1 October 2023
-  long: { day: '2-digit', month: 'long', year: 'numeric' },
+  long: { day: 'numeric', month: 'long', year: 'numeric' },
 };
 
 const DAY_FORMATS: Record<FormatType, Intl.DateTimeFormatOptions> = {
-  // 10
-  short: { day: 'numeric' },
+  // 01
+  short: { day: '2-digit' },
   // 1 Oct
   medium: { day: 'numeric', month: 'short' },
   // 1 October
@@ -78,7 +79,7 @@ export function formatDateRange(startDate: Date, endDate: Date, options: FormatO
 
   if (!startDate) return '';
 
-  if (startDate === endDate) {
+  if (isSameDay(startDate, endDate)) {
     return formatDate(startDate, { format: 'long', locale, timezone });
   }
 

--- a/docker/firebase/Dockerfile
+++ b/docker/firebase/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:24-slim AS base
 
-# Install Java + deps in one layer
-RUN apt-get update && apt-get install -y \
-    openjdk-17-jre-headless \
+# Install Java 21 (Adoptium Temurin) + deps in one layer
+RUN apt-get update && apt-get install -y wget gnupg \
+ && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main" > /etc/apt/sources.list.d/adoptium.list \
+ && apt-get update && apt-get install -y \
+    temurin-21-jre \
     curl \
  && rm -rf /var/lib/apt/lists/*
 

--- a/e2e/tests/event-management/schedule.test.ts
+++ b/e2e/tests/event-management/schedule.test.ts
@@ -31,13 +31,13 @@ test('displays event schedule', async ({ page }) => {
 
   // Check the schedule page
   await expect(page.getByRole('heading', { name: `${event.name} schedule` })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'January 01, 2022' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'January 1, 2022' })).toBeVisible();
   await expect(page.getByText('09:00 to 18:00')).toBeVisible();
   await expect(page.getByText('Main stage')).toBeVisible();
 
   // Go to the next day
   await schedulePage.clickOnNextDay();
-  await expect(page.getByRole('button', { name: 'January 02, 2022' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'January 2, 2022' })).toBeVisible();
 
   // Open the settings
   await schedulePage.clickOnOptions();

--- a/e2e/tests/event-participation/event.test.ts
+++ b/e2e/tests/event-participation/event.test.ts
@@ -42,7 +42,7 @@ test('displays event page', async ({ page }) => {
   await test.step('with CFP open', async () => {
     await eventPage.goto(eventOpen.slug, eventOpen.name);
     await expect(page.getByText('Nantes, France')).toBeVisible();
-    await expect(page.getByText('October 05, 2020')).toBeVisible();
+    await expect(page.getByText('October 5, 2020')).toBeVisible();
     await expect(page.getByText('Call for papers open')).toBeVisible();
     await expect(page.getByText('The event !')).toBeVisible();
     await expect(eventPage.websiteLink).toHaveAttribute('href', 'https://devfest.gdgnantes.com');


### PR DESCRIPTION
# Update on how date are displayed when the conference is only on one day.

**Before:**
<img width="1270" height="256" alt="Capture d’écran 2026-02-12 à 00 36 32" src="https://github.com/user-attachments/assets/8ec65cef-5b10-434f-8386-db1250ff4c49" />

**After:** (only the date of the event is displayed and not repetec)
<img width="1289" height="265" alt="Capture d’écran 2026-02-12 à 00 35 35" src="https://github.com/user-attachments/assets/d02e02c6-028f-4ad8-9524-b42c1f33870b" />

I also force the "0" as prefix, to avoid "9 Juin / 03 Juin" that you can see in the first screenshot.
<img width="1246" height="270" alt="Capture d’écran 2026-02-12 à 00 36 15" src="https://github.com/user-attachments/assets/a02ea779-fcea-48fc-8a0d-0e09547f1202" />

I also update the Dockerfile to make the firebase emulator working on my laptop. Feel free to take this update or not, as I'm not a Docker expert!
