### PR TITLE
fix(multi-select): reset input after selecting a value

### DIFF
--- a/app/design-system/forms/multi-select.test.tsx
+++ b/app/design-system/forms/multi-select.test.tsx
@@ -1,0 +1,40 @@
+import { I18nextProvider } from 'react-i18next';
+import { i18nTest } from 'tests/i18n-helpers.tsx';
+import { page, userEvent } from 'vitest/browser';
+import MultiSelect from './multi-select.tsx';
+
+describe('MultiSelect component', () => {
+  const options = [
+    { value: 'fr', label: 'Français' },
+    { value: 'en', label: 'English' },
+    { value: 'es', label: 'Español' },
+  ];
+
+  const renderComponent = () => {
+    return page.render(
+      <I18nextProvider i18n={i18nTest}>
+        <MultiSelect
+          name="languages"
+          label="Languages"
+          placeholder="Select languages"
+          options={options}
+          defaultValues={[]}
+        />
+      </I18nextProvider>,
+    );
+  };
+
+  it('clears the search input after selecting an option', async () => {
+    await renderComponent();
+
+    const input = page.getByRole('combobox');
+    await userEvent.type(input, 'fr');
+
+    await expect.element(input).toHaveValue('fr');
+
+    await page.getByRole('option', { name: /Français/i }).click();
+
+    await expect.element(input).toHaveValue('');
+    await expect.element(page.getByRole('listitem', { name: /Français/i })).toBeInTheDocument();
+  });
+});

--- a/app/design-system/forms/multi-select.tsx
+++ b/app/design-system/forms/multi-select.tsx
@@ -38,6 +38,7 @@ export default function MultiSelect({ name, label, placeholder, options, default
 
   const handleSelect = (selectedOptions: string[]) => {
     setSelected(selectedOptions);
+    setSearchTerm('');
   };
 
   return (


### PR DESCRIPTION
## ❓ Why

When a user typed a search term (e.g. "fr") and selected an option from the dropdown (e.g. "Français"), the badge was correctly added but the search term remained in the input. This was confusing as it looked like the input was in a dirty state after selection.

## 🧑🏼‍💻 What

- Clear the search input after selecting an option in MultiSelect (setSearchTerm('') in handleSelect)
- Add a test to cover this behaviour (I carried out the simplest possible test for this scenario and to easily target the badge)

## 🧪 How to test

- Go to a form with a MultiSelect (e.g. talk submission → Languages field)
- Type "fr" in the input
- Click "Français" in the dropdown
- Expected: the "Français" badge appears and the input is empty
- Before fix: the input kept "fr" after selection