### PR TITLE
feat: add partial index on proposals for default search query

### DIFF
--- a/prisma/migrations/20260504123339_add_partial_index_proposals_active/migration.sql
+++ b/prisma/migrations/20260504123339_add_partial_index_proposals_active/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "proposals_eventId_submittedAt_idx" ON "proposals"("eventId", "submittedAt" DESC) WHERE ("isDraft" = false AND "archivedAt" IS NULL);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
-  provider = "prisma-client"
-  output   = "./generated"
+  provider        = "prisma-client"
+  output          = "./generated"
+  previewFeatures = ["partialIndexes"]
 }
 
 datasource db {
@@ -285,6 +286,7 @@ model Proposal {
 
   @@unique([talkId, eventId])
   @@unique([proposalNumber, eventId])
+  @@index([eventId, submittedAt(sort: Desc)], where: { isDraft: false, archivedAt: null })
   @@index([eventId])
   @@map("proposals")
 }


### PR DESCRIPTION
Index on (eventId, submittedAt DESC) filtered by isDraft=false and
archivedAt IS NULL replaces sequential scan with index scan for the
main proposals listing hot path.
