### PR TITLE
fix: raise comment limit to 2000 and add character counter

### DIFF
--- a/app/features/conversations/components/message-input-form.test.tsx
+++ b/app/features/conversations/components/message-input-form.test.tsx
@@ -2,7 +2,7 @@ import { I18nextProvider } from 'react-i18next';
 import { createRoutesStub } from 'react-router';
 import { i18nTest } from 'tests/i18n-helpers.ts';
 import { page } from 'vitest/browser';
-import type { Message } from '~/shared/types/conversation.types.ts';
+import { MESSAGE_MAX_LENGTH, type Message } from '~/shared/types/conversation.types.ts';
 import { MessageInputForm } from './message-input-form.tsx';
 
 describe('MessageInputForm component', () => {
@@ -41,6 +41,36 @@ describe('MessageInputForm component', () => {
 
     const textarea = page.getByRole('textbox', { name: 'Message input' });
     expect(textarea).toHaveValue('Existing message');
+  });
+
+  it('caps the textarea to the maximum message length', async () => {
+    await renderComponent();
+
+    const textarea = page.getByRole('textbox', { name: 'Message input' });
+    expect(textarea.element()).toHaveAttribute('maxlength', String(MESSAGE_MAX_LENGTH));
+  });
+
+  it('renders a live character counter that updates while typing', async () => {
+    await renderComponent();
+
+    await expect.element(page.getByText(`0 / ${MESSAGE_MAX_LENGTH}`)).toBeInTheDocument();
+
+    await page.getByRole('textbox', { name: 'Message input' }).fill('hello');
+    await expect.element(page.getByText(`5 / ${MESSAGE_MAX_LENGTH}`)).toBeInTheDocument();
+  });
+
+  it('initializes the character counter from an existing message', async () => {
+    const message: Message = {
+      id: 'msg-1',
+      sender: { userId: 'user-1', name: 'John Doe', picture: null },
+      content: 'Existing message',
+      reactions: [],
+      sentAt: new Date(),
+    };
+
+    await renderComponent({ message });
+
+    await expect.element(page.getByText(`16 / ${MESSAGE_MAX_LENGTH}`)).toBeInTheDocument();
   });
 
   it('renders cancel button when onClose is provided', async () => {

--- a/app/features/conversations/components/message-input-form.tsx
+++ b/app/features/conversations/components/message-input-form.tsx
@@ -1,10 +1,11 @@
 import { formatForDisplay, useHotkey } from '@tanstack/react-hotkeys';
-import { useId, useRef } from 'react';
+import { cx } from 'class-variance-authority';
+import { useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, useFetcher } from 'react-router';
 import { Button } from '~/design-system/button.tsx';
-import { Label } from '~/design-system/typography.tsx';
-import type { Message } from '~/shared/types/conversation.types.ts';
+import { Label, Subtitle } from '~/design-system/typography.tsx';
+import { MESSAGE_MAX_LENGTH, type Message } from '~/shared/types/conversation.types.ts';
 
 type Props = {
   channel: string;
@@ -33,6 +34,7 @@ export function MessageInputForm({
   const formRef = useRef<HTMLFormElement>(null);
   const fetcherKey = message?.id ? `save-message:${message.id}` : 'save-message:new';
   const fetcher = useFetcher({ key: fetcherKey });
+  const [charCount, setCharCount] = useState(message?.content?.length ?? 0);
 
   const handleSubmit = async (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -44,6 +46,7 @@ export function MessageInputForm({
 
     await fetcher.submit(formData, { method: 'POST', preventScrollReset: true, flushSync: true });
     formRef.current?.reset();
+    setCharCount(message?.content?.length ?? 0);
   };
 
   const isLoading = fetcher.state === 'submitting';
@@ -65,7 +68,9 @@ export function MessageInputForm({
           id={inputId}
           name="message"
           required
+          maxLength={MESSAGE_MAX_LENGTH}
           defaultValue={message?.content}
+          onChange={(event) => setCharCount(event.target.value.length)}
           aria-label={inputLabel}
           placeholder={placeholder}
           autoComplete="off"
@@ -89,6 +94,14 @@ export function MessageInputForm({
           disabled={isLoading}
         >
           {buttonLabel || t('common.save')}
+          <kbd
+            className={cx('ml-2 hidden font-sans font-normal sm:inline', {
+              'text-white': Boolean(onClose),
+              'text-gray-500': !onClose,
+            })}
+          >
+            {formatForDisplay('Mod+Enter')}
+          </kbd>
         </Button>
 
         {onClose ? (
@@ -97,9 +110,11 @@ export function MessageInputForm({
           </Button>
         ) : null}
 
-        <p className="mr-auto hidden self-end text-xs text-gray-500 sm:block">
-          <kbd>{formatForDisplay('Mod+Enter', { useSymbols: false })}</kbd> {t('common.shortcut-to-send')}
-        </p>
+        <div className="mr-auto self-end">
+          <Subtitle size="xs" variant={charCount >= MESSAGE_MAX_LENGTH ? 'error' : 'secondary'}>
+            {charCount} / {MESSAGE_MAX_LENGTH}
+          </Subtitle>
+        </div>
       </div>
     </Form>
   );

--- a/app/features/conversations/services/conversation.schema.server.test.ts
+++ b/app/features/conversations/services/conversation.schema.server.test.ts
@@ -1,0 +1,21 @@
+import { MESSAGE_MAX_LENGTH } from '~/shared/types/conversation.types.ts';
+import { ConversationMessageSaveSchema } from './conversation.schema.server.ts';
+
+describe('ConversationMessageSaveSchema', () => {
+  it('accepts a message at the maximum length', () => {
+    const result = ConversationMessageSaveSchema.safeParse({ message: 'a'.repeat(MESSAGE_MAX_LENGTH) });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a message over the maximum length', () => {
+    const result = ConversationMessageSaveSchema.safeParse({ message: 'a'.repeat(MESSAGE_MAX_LENGTH + 1) });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.at(0)?.message).toBe('The message is too long');
+  });
+
+  it('rejects an empty message', () => {
+    const result = ConversationMessageSaveSchema.safeParse({ message: '' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.at(0)?.message).toBe('A message is required');
+  });
+});

--- a/app/features/conversations/services/conversation.schema.server.ts
+++ b/app/features/conversations/services/conversation.schema.server.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+import { MESSAGE_MAX_LENGTH } from '~/shared/types/conversation.types.ts';
 
 const ConversationChannelSchema = z.enum(['comment', 'speaker']);
 
 export const ConversationMessageSaveSchema = z.object({
   id: z.string().optional(),
-  message: z.string().min(1, 'A message is required').max(500),
+  message: z.string().min(1, 'A message is required').max(MESSAGE_MAX_LENGTH, 'The message is too long'),
 });
 
 export const ConversationMessageReactSchema = z.object({

--- a/app/locales/en.translation.json
+++ b/app/locales/en.translation.json
@@ -293,7 +293,6 @@
   "common.my-reviews": "My reviews",
   "common.reviews": "Reviews",
   "common.save": "Save",
-  "common.shortcut-to-send": "to submit",
   "common.search.placeholder": "Search...",
   "common.see-all-proposals": "See all proposals",
   "common.select": "Select",

--- a/app/locales/fr.translation.json
+++ b/app/locales/fr.translation.json
@@ -293,7 +293,6 @@
   "common.my-reviews": "Mes évaluations",
   "common.reviews": "Évaluations",
   "common.save": "Enregistrer",
-  "common.shortcut-to-send": "pour envoyer",
   "common.search.placeholder": "Rechercher...",
   "common.see-all-proposals": "Voir toutes les propositions",
   "common.select": "Sélectionner",

--- a/app/shared/types/conversation.types.ts
+++ b/app/shared/types/conversation.types.ts
@@ -1,5 +1,7 @@
 import type { EmojiReaction } from './emojis.types.ts';
 
+export const MESSAGE_MAX_LENGTH = 2000;
+
 type MessageRole = 'SPEAKER' | 'ORGANIZER';
 
 export type Message = {


### PR DESCRIPTION
Comments over 500 characters failed with a vague "An error has occurred"
toast and the typed content was lost. Raise the shared conversation message
limit to 2000 characters and add a client-side guard so users see the limit.

- Add a shared MESSAGE_MAX_LENGTH constant used by both the Zod schema and
  the input form to keep the client cap and server validation in sync
- Add a hard maxLength and a live "N / 2000" counter (red at the cap) to
  MessageInputForm
- Give the schema max() a custom error message

Closes #799
