### PR TITLE
Improve select-all checkbox clarity in proposals list

### DIFF
--- a/app/design-system/list/use-list-selection.tsx
+++ b/app/design-system/list/use-list-selection.tsx
@@ -1,8 +1,9 @@
 import type { ChangeEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+export type SelectAllState = 'none' | 'partial' | 'page' | 'all';
+
 export const useListSelection = (ids: Array<string>, total: number, hash: string) => {
-  const ref = useRef<HTMLInputElement>(null);
   const lastHash = useRef<string>(null);
   const [selection, setSelection] = useState<Array<string>>([]);
   const [allPagesSelected, setAllPagesSelected] = useState(false);
@@ -55,31 +56,27 @@ export const useListSelection = (ids: Array<string>, total: number, hash: string
     lastHash.current = hash;
   }, [hash, reset]);
 
-  useEffect(() => {
-    if (!ref.current) return;
-    ref.current.disabled = total === 0;
-    ref.current.checked = (total !== 0 && selection.length === total) || allPagesSelected;
-    ref.current.indeterminate = selection.length > 0 && selection.length < total;
-    ref.current.onchange = toggleAll;
-  }, [selection, ids, toggleAll, total, allPagesSelected]);
+  const selectAllState: SelectAllState = useMemo(() => {
+    if (allPagesSelected) return 'all';
+    if (selection.length === 0) return 'none';
+    if (ids.length > 0 && selection.length === ids.length) return 'page';
+    return 'partial';
+  }, [selection, ids, allPagesSelected]);
 
   return useMemo(
     () => ({
-      ref,
+      selectAllState,
+      selectAllDisabled: total === 0,
       selection,
       totalSelected: allPagesSelected ? total : selection.length,
       reset,
       isSelected,
-      isCurrentPageSelected: arraysEqual(selection, ids) && selection.length !== total,
+      isCurrentPageSelected: selectAllState === 'page',
       isAllPagesSelected: allPagesSelected,
       toggle,
+      toggleAll,
       toggleAllPages,
     }),
-    [ref, reset, isSelected, toggle, toggleAllPages, allPagesSelected, selection, ids, total],
+    [selectAllState, reset, isSelected, toggle, toggleAll, toggleAllPages, allPagesSelected, selection, total],
   );
 };
-
-function arraysEqual(a: Array<string>, b: Array<string>) {
-  if (a.length !== b.length) return false;
-  return a.every((item) => b.includes(item));
-}

--- a/app/features/event-management/proposals/components/list/header/header.tsx
+++ b/app/features/event-management/proposals/components/list/header/header.tsx
@@ -2,14 +2,14 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router';
 import { useUserTeamPermissions } from '~/app-platform/components/user-context.tsx';
 import { StatusPill } from '~/design-system/charts/status-pill.tsx';
-import { Checkbox } from '~/design-system/forms/input-checkbox.tsx';
 import { List } from '~/design-system/list/list.tsx';
 import { Text } from '~/design-system/typography.tsx';
 import { ReviewsProgress } from '../../shared/reviews-progress.tsx';
 import { DeliberationButton } from './deliberation-button.tsx';
+import { SelectAllCheckbox, type SelectAllProps } from './select-all-checkbox.tsx';
 
 type Props = {
-  checkboxRef: React.RefObject<HTMLInputElement | null>;
+  selectAll: SelectAllProps;
   total: number;
   totalSelected: number;
   totalReviewed: number;
@@ -19,7 +19,7 @@ type Props = {
 };
 
 export function ListHeader({
-  checkboxRef,
+  selectAll,
   total,
   totalSelected,
   totalReviewed,
@@ -34,7 +34,7 @@ export function ListHeader({
     <List.Header className="bg-gray-50">
       <div className="flex flex-col gap-4 sm:h-7 md:flex-row md:items-center">
         {permissions.canChangeProposalStatus ? (
-          <Checkbox aria-label={t('event-management.proposals.list.check-item')} ref={checkboxRef}>
+          <SelectAllCheckbox {...selectAll} aria-label={t('event-management.proposals.list.check-item')}>
             {totalSelected === 0 ? (
               <Trans
                 i18nKey="event-management.proposals.list.items"
@@ -44,7 +44,7 @@ export function ListHeader({
             ) : (
               t('event-management.proposals.list.selected', { count: totalSelected })
             )}
-          </Checkbox>
+          </SelectAllCheckbox>
         ) : (
           <Text>
             <Trans

--- a/app/features/event-management/proposals/components/list/header/header.tsx
+++ b/app/features/event-management/proposals/components/list/header/header.tsx
@@ -31,7 +31,7 @@ export function ListHeader({
   const permissions = useUserTeamPermissions();
 
   return (
-    <List.Header className="py-2">
+    <List.Header className="bg-gray-50">
       <div className="flex flex-col gap-4 sm:h-7 md:flex-row md:items-center">
         {permissions.canChangeProposalStatus ? (
           <Checkbox aria-label={t('event-management.proposals.list.check-item')} ref={checkboxRef}>

--- a/app/features/event-management/proposals/components/list/header/select-all-checkbox.tsx
+++ b/app/features/event-management/proposals/components/list/header/select-all-checkbox.tsx
@@ -1,0 +1,68 @@
+import { Checkbox } from '@headlessui/react';
+import { cx } from 'class-variance-authority';
+import type { ReactNode } from 'react';
+import type { SelectAllState } from '~/design-system/list/use-list-selection.tsx';
+import { Text } from '~/design-system/typography.tsx';
+
+export type SelectAllProps = {
+  state: SelectAllState;
+  disabled?: boolean;
+  onChange: VoidFunction;
+};
+
+type SelectAllCheckboxProps = SelectAllProps & {
+  children?: ReactNode;
+  'aria-label': string;
+};
+
+export function SelectAllCheckbox({ state, disabled, onChange, children, ...rest }: SelectAllCheckboxProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+        {state === 'all' && (
+          <span aria-hidden="true" className="absolute -top-1 -right-1 h-4 w-4 rounded-sm border border-indigo-300" />
+        )}
+        <Checkbox
+          checked={state === 'page' || state === 'all'}
+          indeterminate={state === 'partial'}
+          disabled={disabled}
+          onChange={onChange}
+          aria-label={rest['aria-label']}
+          className={cx(
+            'relative flex h-4 w-4 items-center justify-center rounded-sm border transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 focus-visible:outline-hidden',
+            state === 'none' ? 'border-gray-300 bg-white' : 'border-indigo-600 bg-indigo-600',
+            disabled && 'cursor-not-allowed opacity-50',
+          )}
+        >
+          <CheckboxIcon state={state} />
+        </Checkbox>
+      </div>
+      {children && <Text>{children}</Text>}
+    </div>
+  );
+}
+
+function CheckboxIcon({ state }: { state: SelectAllState }) {
+  if (state === 'none') return null;
+
+  if (state === 'partial') {
+    return (
+      <svg viewBox="0 0 16 16" className="h-2.5 w-2.5" aria-hidden="true">
+        <rect x="4" y="7.25" width="8" height="1.5" rx="0.75" fill="white" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 16 16" className="h-2.5 w-2.5" aria-hidden="true">
+      <path
+        d="M2.5 8.2L6 11.6L13.5 3.6"
+        fill="none"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/app/features/event-management/proposals/components/list/proposals-list.tsx
+++ b/app/features/event-management/proposals/components/list/proposals-list.tsx
@@ -26,7 +26,11 @@ export function ProposalsList({ team, event, proposals, pagination, statistics, 
   return (
     <List>
       <ListHeader
-        checkboxRef={selector.ref}
+        selectAll={{
+          state: selector.selectAllState,
+          disabled: selector.selectAllDisabled,
+          onChange: selector.toggleAll,
+        }}
         total={statistics.total}
         totalReviewed={statistics.reviewed}
         hasNewMessages={statistics.hasNewMessages}


### PR DESCRIPTION
## Summary
- **Clearer visual separation**: the select-all checkbox now sits in a shaded toolbar-style header instead of blending into the row right below it, so it's no longer easy to confuse with the first proposal's own checkbox.
- **The checkbox now matches what you actually selected**: checking every proposal on the page shows a fully checked box, not the same "some selected" dash used for partial selections. Before, a fully selected page and a partial selection looked identical.
- **"All pages" now looks different from "this page"**: after using the banner link to select every proposal across all pages, the checkbox shows a distinct stacked-square glyph instead of looking the same as "just this page selected" — so it's clear at a glance whether the next bulk action (accept/reject) will apply to the current page or to everything matching your filters.

Discussion: #694

## ⚠️ Behavior change to review
- The select-all checkbox used to show the same "indeterminate" dash whether some or *all* items on the current page were selected. It now shows a full check for "all items on this page" — reviewers/QA already familiar with the old behavior should double check this reads as intentional, not as a regression.
- The checkbox is no longer a native `<input type="checkbox">` — it's now a Headless UI `role="checkbox"` element, needed to render the custom "all pages" glyph. Keyboard and screen-reader behavior is equivalent, but flag if anything (tests, CSS) targeted the native input directly.

**To verify manually**: on a filtered result spanning multiple pages, select every proposal on the current page (checkbox should go fully checked, not dashed), then use the banner's "select all N" link (checkbox should show the stacked-square glyph, distinct from the plain check).
